### PR TITLE
Remove mention of AUR helpers

### DIFF
--- a/doc/install/ARCHLINUX.md
+++ b/doc/install/ARCHLINUX.md
@@ -1,26 +1,19 @@
-Install IKOS on Archlinux
-=========================
+Install IKOS on Arch Linux
+==========================
 
-Here are the steps to install IKOS on **[Archlinux](https://www.archlinux.org/)** using **[AUR](https://aur.archlinux.org/)** (Archlinux User Repositories).
+IKOS can be installed on **[Arch Linux](https://www.archlinux.org/)** by building and installing the *apron* and *ikos* **[AUR](https://aur.archlinux.org/)** packages. See **[Installing packages](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages)** for detailed instructions.
 
-First, make sure your system is up-to-date:
-
-```
-$ sudo pacman -Syu
-```
-
-Now, install IKOS using your favorite **AUR** helper:
-
-```
-$ yay -S ikos
-```
+* https://aur.archlinux.org/packages/apron
+* https://aur.archlinux.org/packages/ikos
 
 You are now ready to use IKOS. Go to the section [How to Run IKOS](../../README.md#how-to-run-ikos) in README.md
+
+To be informed on updates by email, click on "Enable notifications" in "Package actions" on the AUR website.
 
 Build IKOS from source on Archlinux
 ===================================
 
-Here are the steps to install the required dependencies to build IKOS from source on **[Archlinux](https://www.archlinux.org/)** using **[AUR](https://aur.archlinux.org/)** (Archlinux User Repositories).
+Here are the steps to install the required dependencies to build IKOS from source on **[Arch Linux](https://www.archlinux.org/)** using **[AUR](https://aur.archlinux.org/)** (Archlinux User Repositories).
 
 First, make sure your system is up-to-date:
 
@@ -28,10 +21,14 @@ First, make sure your system is up-to-date:
 $ sudo pacman -Syu
 ```
 
-Now, install the following packages using your favorite **AUR** helper:
+Now, install the following packages using **pacman**:
 
 ```
-$ yay -S base-devel cmake gmp boost boost-libs python python-pygments sqlite llvm llvm-libs clang apron-ppl-svn
+$ sudo pacman -S base-devel cmake gmp boost boost-libs python python-pygments sqlite llvm llvm-libs clang
 ```
+
+Now install and build the apron package.
+
+* https://aur.archlinux.org/packages/apron
 
 You are now ready to build IKOS. Go to the section [Build and Install](../../README.md#build-and-install) in README.md


### PR DESCRIPTION
AUR helpers are fully unsupported by the Arch Linux development team. Besides my statement as a [Trusted User](https://www.archlinux.org/people/trusted-users/#Alad), see the following links:

https://bbs.archlinux.org/viewtopic.php?pid=828310#p828310
https://wiki.archlinux.org/index.php/AUR_helpers
https://bugs.archlinux.org/task/56602#comment164090

Besides these considerations, the AUR itself has in 2015 adopted git, making these helpers for simple tasks such as these (one package and one dependency) obsolete. Users can easily keep track of updates by enabling email notifications on the AUR website.