### PR TITLE
[cmake] Link ikos-analyzer to pthreads (closes #144)

### DIFF
--- a/analyzer/CMakeLists.txt
+++ b/analyzer/CMakeLists.txt
@@ -95,6 +95,8 @@ endmacro()
 # Add path for custom modules
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
 
+find_package(Threads REQUIRED)
+
 set(CUSTOM_BOOST_ROOT "" CACHE PATH "Path to custom boost installation")
 if (CUSTOM_BOOST_ROOT)
   set(BOOST_ROOT "${CUSTOM_BOOST_ROOT}")
@@ -285,6 +287,7 @@ else()
   )
 endif()
 target_link_libraries(ikos-analyzer
+  Threads::Threads
   ${FRONTEND_LLVM_TO_AR_LIB}
   ${IKOS_ANALYZER_LLVM_LIBS}
   ${SQLITE3_LIB}


### PR DESCRIPTION
ikos-analyzer was not explicitly linked to pthreads, which caused a
symbol lookup error (the wording may differ depending on the Linux
distribution):

```
/usr/bin/clang++  -fPIC -fvisibility-inlines-hidden -std=c++11 -w
-fdiagnostics-color -ffunction-sections -fdata-sections -O3 -DNDEBUG
analyzer/CMakeFiles/ikos-analyzer.dir/src/ikos_analyzer.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/call_context.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/fixpoint_parameters.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/hardware_addresses.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/literal.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/liveness.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/memory_location.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/option.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/pointer/constraint.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/pointer/function.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/pointer/pointer.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/pointer/value.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/global_variable.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/interprocedural/function_fixpoint.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/interprocedural/global_init_fixpoint.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/interprocedural/init_invariant.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/interprocedural/interprocedural.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/interprocedural/progress.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/intraprocedural/function_fixpoint.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/intraprocedural/intraprocedural.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/machine_int_domain/apron_interval.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/machine_int_domain/apron_octagon.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/machine_int_domain/apron_pkgrid_polyhedra_lin_cong.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/machine_int_domain/apron_polka_linear_equalities.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/widening_hint.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/machine_int_domain/apron_polka_polyhedra.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/machine_int_domain/apron_ppl_linear_congruences.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/machine_int_domain/apron_ppl_polyhedra.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/machine_int_domain/congruence.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/machine_int_domain/dbm.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/machine_int_domain/gauge.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/machine_int_domain/gauge_interval_congruence.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/machine_int_domain/interval.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/machine_int_domain/interval_congruence.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/machine_int_domain/var_pack_apron_octagon.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/machine_int_domain/var_pack_apron_pkgrid_polyhedra_lin_cong.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/machine_int_domain/var_pack_apron_polka_linear_equalities.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/machine_int_domain/var_pack_apron_polka_polyhedra.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/machine_int_domain/var_pack_apron_ppl_linear_congruences.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/machine_int_domain/var_pack_apron_ppl_polyhedra.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/machine_int_domain/var_pack_dbm.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/machine_int_domain/var_pack_dbm_congruence.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/variable.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/checker/assert_prover.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/checker/buffer_overflow.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/checker/checker.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/checker/dead_code.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/checker/debug.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/checker/division_by_zero.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/checker/double_free.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/checker/function_call.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/checker/int_overflow_base.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/checker/memory_watch.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/checker/null_dereference.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/checker/pointer_alignment.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/checker/pointer_compare.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/checker/pointer_overflow.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/checker/shift_count.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/checker/signed_int_overflow.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/checker/soundness.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/checker/uninitialized_variable.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/checker/unsigned_int_overflow.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/database/output.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/database/sqlite.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/database/table.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/database/table/call_contexts.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/database/table/checks.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/database/table/files.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/database/table/functions.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/database/table/memory_locations.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/database/table/operands.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/database/table/settings.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/database/table/statements.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/database/table/times.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/exception.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/json/json.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/util/color.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/util/log.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/util/progress.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/util/source_location.cpp.o
analyzer/CMakeFiles/ikos-analyzer.dir/src/util/timer.cpp.o  -o
analyzer/ikos-analyzer
-Wl,-rpath,/home/ave/Documents/code/oss/ikos/build/frontend/llvm:/home/ave/Documents/code/oss/ikos/build/ar:
frontend/llvm/libikos-llvm-to-ar.so /usr/lib64/libLLVM.so.8
/usr/lib64/libsqlite3.so /usr/lib64/libboost_filesystem.so
/usr/lib64/libboost_system.so /usr/lib64/libgmp.so
/usr/lib64/libgmpxx.so ar/libikos-ar.so /usr/lib64/libLLVM.so.8
/usr/lib64/libgmp.so /usr/lib64/libgmpxx.so && :
/usr/bin/ld: analyzer/CMakeFiles/ikos-analyzer.dir/src/analysis/value/interprocedural/progress.cpp.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
/usr/bin/ld: /lib64/libpthread.so.0: error adding symbols: DSO missing from command line
```

Tested on openSUSE Tumbleweed 20190730.