### PR TITLE
[doc] Update TROUBLESHOOTING.md: "cannot find -lLLVMCore"

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -57,6 +57,12 @@ Unfortunately, this doesn't work because LLVM uses global constructors to regist
 
 Compiling IKOS with both `-DBUILD_SHARED_LIBS=ON` and `-DIKOS_LINK_LLVM_DYLIB=ON` should fix the issue by linking against the libLLVM shared library.
 
+### "/usr/bin/ld: cannot find -lLLVMCore" while running Make
+
+Your LLVM library was built as one single shared library `libLLVM.so` (`LLVM_BUILD_LLVM_DYLIB=1`), but CMake was configured to query specific library components and match link flags against them.
+
+Compiling IKOS with both `-DBUILD_SHARED_LIBS=ON` and `-DIKOS_LINK_LLVM_DYLIB=ON` should fix the issue by linking against the single libLLVM shared library.
+
 Analysis issues
 ---------------
 


### PR DESCRIPTION
The issue occurs when LLVM is compiled as one big shared library:

```
/usr/bin/clang++  -fPIC -fvisibility-inlines-hidden -std=c++11 -w
-fdiagnostics-color -ffunction-sections -fdata-sections -O3 -DNDEBUG
frontend/llvm/CMakeFiles/ikos-import.dir/src/ikos_import.cpp.o  -o
frontend/llvm/ikos-import  frontend/llvm/libikos-llvm-to-ar.a -lLLVMCore
-lLLVMipo -lLLVMIRReader -lLLVMSupport -lLLVMTransformUtils
ar/libikos-ar.a /usr/lib64/libboost_filesystem.so
/usr/lib64/libboost_system.so /usr/lib64/libgmp.so
/usr/lib64/libgmpxx.so && :
/usr/bin/ld: cannot find -lLLVMCore
/usr/bin/ld: cannot find -lLLVMipo
/usr/bin/ld: cannot find -lLLVMIRReader
/usr/bin/ld: cannot find -lLLVMSupport
/usr/bin/ld: cannot find -lLLVMTransformUtils
```

See also: 54500c4fa5ceda972ac1efc5b4ce9c9813384cca