### PR TITLE
Upgrade to LLVM 11

### DIFF
--- a/analyzer/CMakeLists.txt
+++ b/analyzer/CMakeLists.txt
@@ -121,9 +121,14 @@ include_directories(${FRONTEND_LLVM_INCLUDE_DIR})
 
 find_package(LLVM REQUIRED)
 include_directories(SYSTEM ${LLVM_INCLUDE_DIR})
+if (LLVM_FOUND)
+  if (LLVM_VERSION_MAJOR VERSION_EQUAL "9")
+    add_definitions("-DHAS_LLVM_9")
+  endif()
+endif()
 
-if ((LLVM_VERSION VERSION_LESS "9") OR (NOT (LLVM_VERSION VERSION_LESS "10")))
-  message(FATAL_ERROR "LLVM 9 is required.")
+if ((LLVM_VERSION VERSION_LESS "9") OR (NOT (LLVM_VERSION VERSION_LESS "12")))
+  message(FATAL_ERROR "LLVM 9/10/11 is required.")
 endif()
 
 # Add path to llvm cmake modules

--- a/analyzer/include/ikos/analyzer/analysis/variable.hpp
+++ b/analyzer/include/ikos/analyzer/analysis/variable.hpp
@@ -407,6 +407,9 @@ public:
   /// \brief Default constructor
   NamedShadowVariable(ar::Type* type, std::string name);
 
+  /// \brief Default constructor
+  NamedShadowVariable(ar::Type* type, llvm::StringRef name);
+
   /// \brief Get the variable name
   const std::string& name() const { return this->_name; }
 

--- a/analyzer/include/ikos/analyzer/json/json.hpp
+++ b/analyzer/include/ikos/analyzer/json/json.hpp
@@ -45,6 +45,7 @@
 
 #include <string>
 
+#include <llvm/ADT/StringRef.h>
 #include <ikos/analyzer/support/number.hpp>
 
 namespace ikos {
@@ -172,6 +173,11 @@ public:
 /// \brief Convert strings to JsonString
 inline JsonString to_json(std::string s) {
   return JsonString(std::move(s));
+}
+
+/// \brief Convert strings to JsonString
+inline JsonString to_json(llvm::StringRef s) {
+  return JsonString(std::move(s.str()));
 }
 
 /// \brief Convert strings to JsonString

--- a/analyzer/include/ikos/analyzer/util/demangle.hpp
+++ b/analyzer/include/ikos/analyzer/util/demangle.hpp
@@ -95,5 +95,11 @@ inline std::string demangle(StringRef name) {
   return demangle(name.to_string());
 }
 
+/// \brief Return the demangled symbol name, or name if it is not mangled
+inline std::string demangle(llvm::StringRef name) {
+  // boost::core::demangle requires a null-terminated string
+  return demangle(name.str());
+}
+
 } // end namespace analyzer
 } // end namespace ikos

--- a/analyzer/src/analysis/variable.cpp
+++ b/analyzer/src/analysis/variable.cpp
@@ -180,6 +180,11 @@ NamedShadowVariable::NamedShadowVariable(ar::Type* type, std::string name)
   ikos_assert(!this->_name.empty());
 }
 
+NamedShadowVariable::NamedShadowVariable(ar::Type* type, llvm::StringRef name)
+    : Variable(NamedShadowVariableKind, type), _name(std::move(name.str())) {
+  ikos_assert(!this->_name.empty());
+}
+
 void NamedShadowVariable::dump(std::ostream& o) const {
   o << this->_name;
 }

--- a/analyzer/src/database/table/memory_locations.cpp
+++ b/analyzer/src/database/table/memory_locations.cpp
@@ -169,7 +169,7 @@ JsonDict MemoryLocationsTable::info(MemoryLocation* mem_loc) {
 
     // Last chance, use llvm variable name
     if (llvm_gv->hasName()) {
-      std::string name = llvm_gv->getName();
+      std::string name = llvm_gv->getName().str();
       if (is_mangled(name)) {
         return {{"name", name}, {"demangle", demangle(name)}};
       } else {

--- a/analyzer/src/database/table/operands.cpp
+++ b/analyzer/src/database/table/operands.cpp
@@ -46,6 +46,7 @@
 
 #include <boost/container/flat_set.hpp>
 
+#include <llvm/ADT/SmallString.h>
 #include <llvm/IR/DebugInfoMetadata.h>
 #include <llvm/IR/InlineAsm.h>
 #include <llvm/IR/Instructions.h>
@@ -163,7 +164,7 @@ std::string to_string(const llvm::APInt& n) {
 std::string to_string(const llvm::APFloat& f) {
   llvm::SmallString< 16 > str;
   f.toString(str, /*FormatPrecision=*/0, /*FormatMaxPadding=*/0);
-  return str.str();
+  return str.str().str();
 }
 
 /// \brief Return the hexadecimal character for the given number
@@ -359,7 +360,7 @@ std::string repr(llvm::Type* type, TypeSet seen) {
       llvm::StringRef name = struct_type->getName();
       name.consume_front("struct.");
       name.consume_front("class.");
-      return name;
+      return name.str();
     }
 
     if (struct_type->isOpaque()) {
@@ -701,7 +702,7 @@ ReprResult repr(llvm::Value* value, ValueSet seen) {
       llvm::StringRef name = di_var->getName();
 
       if (!name.empty()) {
-        return ReprResult{name, pointee_type(di_type)};
+        return ReprResult{name.str(), pointee_type(di_type)};
       }
     }
   }

--- a/cmake/FindLLVM.cmake
+++ b/cmake/FindLLVM.cmake
@@ -59,6 +59,7 @@ if (NOT LLVM_FOUND)
     endfunction()
 
     run_llvm_config("--version" LLVM_VERSION)
+    string(REGEX REPLACE "[.].*" "" LLVM_VERSION_MAJOR ${LLVM_VERSION})
 
     run_llvm_config("--prefix" LLVM_ROOT)
     file(TO_CMAKE_PATH "${LLVM_ROOT}" LLVM_ROOT)

--- a/frontend/llvm/CMakeLists.txt
+++ b/frontend/llvm/CMakeLists.txt
@@ -102,9 +102,14 @@ include_directories(${AR_INCLUDE_DIR})
 
 find_package(LLVM REQUIRED)
 include_directories(SYSTEM ${LLVM_INCLUDE_DIR})
+if (LLVM_FOUND)
+  if (LLVM_VERSION_MAJOR VERSION_EQUAL "9")
+    add_definitions("-DHAS_LLVM_9")
+  endif()
+endif()
 
-if ((LLVM_VERSION VERSION_LESS "9") OR (NOT (LLVM_VERSION VERSION_LESS "10")))
-  message(FATAL_ERROR "LLVM 9 is required.")
+if ((LLVM_VERSION VERSION_LESS "9") OR (NOT (LLVM_VERSION VERSION_LESS "12")))
+  message(FATAL_ERROR "LLVM 9/10/11 is required.")
 endif()
 
 # Add path to llvm cmake modules

--- a/frontend/llvm/src/ikos_pp.cpp
+++ b/frontend/llvm/src/ikos_pp.cpp
@@ -52,6 +52,7 @@
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Verifier.h>
 #include <llvm/IRReader/IRReader.h>
+#include <llvm/InitializePasses.h>
 #include <llvm/LinkAllPasses.h>
 #include <llvm/Support/CommandLine.h>
 #include <llvm/Support/Debug.h>

--- a/frontend/llvm/src/import/bundle.cpp
+++ b/frontend/llvm/src/import/bundle.cpp
@@ -71,7 +71,7 @@ ar::GlobalVariable* BundleImporter::translate_global_variable(
 
   std::string name;
   if (gv->hasName()) {
-    name = gv->getName();
+    name = gv->getName().str();
   } else {
     name = this->_bundle->find_available_name("__unnamed_global_var");
   }

--- a/frontend/llvm/src/import/data_layout.cpp
+++ b/frontend/llvm/src/import/data_layout.cpp
@@ -62,9 +62,17 @@ std::unique_ptr< ar::DataLayout > translate_data_layout(
       llvm_data_layout.isLittleEndian() ? ar::LittleEndian : ar::BigEndian;
 
   // Translate pointer size and alignments
-  ar::DataLayoutInfo pointers(llvm_data_layout.getPointerSizeInBits(),
-                              llvm_data_layout.getPointerABIAlignment(0),
-                              llvm_data_layout.getPointerPrefAlignment());
+#if HAS_LLVM_9
+  ar::DataLayoutInfo
+      pointers(llvm_data_layout.getPointerSizeInBits(),
+               llvm_data_layout.getPointerABIAlignment(0),
+               llvm_data_layout.getPointerPrefAlignment());
+#else
+  ar::DataLayoutInfo
+      pointers(llvm_data_layout.getPointerSizeInBits(),
+               llvm_data_layout.getPointerABIAlignment(0).value(),
+               llvm_data_layout.getPointerPrefAlignment().value());
+#endif
 
   // Create ar::DataLayout
   std::unique_ptr< ar::DataLayout > ar_data_layout =

--- a/frontend/llvm/src/import/function.cpp
+++ b/frontend/llvm/src/import/function.cpp
@@ -1534,9 +1534,16 @@ ar::IntegerConstant* FunctionImporter::translate_indexes(
                     ->getElementOffset(idx);
     } else if (auto seq_type =
                    llvm::dyn_cast< llvm::SequentialType >(indexed_type)) {
+#if HAS_LLVM_9
       ar::ZNumber element_size(
           this->_llvm_data_layout.getTypeAllocSize(seq_type->getElementType()));
       offset += element_size * idx;
+#else
+      ar::ZNumber element_size(
+          this->_llvm_data_layout.getTypeAllocSize(seq_type->getElementType())
+              .getFixedSize());
+      offset += element_size * idx;
+#endif
     } else {
       throw ImportError("unsupported operand to llvm extractvalue");
     }
@@ -1570,8 +1577,16 @@ void FunctionImporter::translate_extractelement(
     throw ImportError("unsupported operand to llvm extractelement");
   }
   auto size_type = ar::IntegerType::size_type(this->_bundle);
-  ar::ZNumber element_size(this->_llvm_data_layout.getTypeAllocSize(
-      inst->getVectorOperandType()->getElementType()));
+#if HAS_LLVM_9
+  ar::ZNumber element_size(
+      this->_llvm_data_layout
+          .getTypeAllocSize(inst->getVectorOperandType()->getElementType()));
+#else
+  ar::ZNumber element_size(
+      this->_llvm_data_layout
+          .getTypeAllocSize(inst->getVectorOperandType()->getElementType())
+          .getFixedSize());
+#endif
   ar::ZNumber offset_value = index->getZExtValue() * element_size;
   auto offset = ar::IntegerConstant::get(this->_context,
                                          size_type,
@@ -1602,8 +1617,16 @@ void FunctionImporter::translate_insertelement(
     throw ImportError("unsupported operand to llvm insertelement");
   }
   auto size_type = ar::IntegerType::size_type(this->_bundle);
-  ar::ZNumber element_size(this->_llvm_data_layout.getTypeAllocSize(
-      inst->getType()->getElementType()));
+#if HAS_LLVM_9
+  ar::ZNumber element_size(
+      this->_llvm_data_layout
+          .getTypeAllocSize(inst->getType()->getElementType()));
+#else
+  ar::ZNumber element_size(
+      this->_llvm_data_layout
+          .getTypeAllocSize(inst->getType()->getElementType())
+          .getFixedSize());
+#endif
   ar::ZNumber offset_value = index->getZExtValue() * element_size;
   auto offset = ar::IntegerConstant::get(this->_context,
                                          size_type,

--- a/frontend/llvm/src/import/type.cpp
+++ b/frontend/llvm/src/import/type.cpp
@@ -138,12 +138,23 @@ void TypeWithSignImporter::sanity_check_size(llvm::Type* llvm_type,
     return;
   }
 
+#if HAS_LLVM_9
   check_import(this->_llvm_data_layout.getTypeSizeInBits(llvm_type) >=
                    this->_ar_data_layout.size_in_bits(ar_type),
                "llvm type size in bits is smaller than ar type size");
   check_import(this->_llvm_data_layout.getTypeAllocSize(llvm_type) ==
                    this->_ar_data_layout.alloc_size_in_bytes(ar_type),
                "llvm type and ar type alloc size are different");
+#else
+  check_import(this->_llvm_data_layout.getTypeSizeInBits(llvm_type)
+                       .getFixedSize() >=
+                   this->_ar_data_layout.size_in_bits(ar_type),
+               "llvm type size in bits is smaller than ar type size");
+  check_import(this->_llvm_data_layout.getTypeAllocSize(llvm_type)
+                       .getFixedSize() ==
+                   this->_ar_data_layout.alloc_size_in_bytes(ar_type),
+               "llvm type and ar type alloc size are different");
+#endif
 }
 
 ar::VoidType* TypeWithSignImporter::translate_void_type(
@@ -410,12 +421,23 @@ void TypeWithDebugInfoImporter::sanity_check_size(llvm::Type* llvm_type,
     return;
   }
 
+#if HAS_LLVM_9
   check_import(this->_llvm_data_layout.getTypeSizeInBits(llvm_type) >=
                    this->_ar_data_layout.size_in_bits(ar_type),
                "llvm type size in bits is smaller than ar type size");
   check_import(this->_llvm_data_layout.getTypeAllocSize(llvm_type) ==
                    this->_ar_data_layout.alloc_size_in_bytes(ar_type),
                "llvm type and ar type alloc size are different");
+#else
+  check_import(this->_llvm_data_layout.getTypeSizeInBits(llvm_type)
+                       .getFixedSize() >=
+                   this->_ar_data_layout.size_in_bits(ar_type),
+               "llvm type size in bits is smaller than ar type size");
+  check_import(this->_llvm_data_layout.getTypeAllocSize(llvm_type)
+                       .getFixedSize() ==
+                   this->_ar_data_layout.alloc_size_in_bytes(ar_type),
+               "llvm type and ar type alloc size are different");
+#endif
 }
 
 ar::Type* TypeWithDebugInfoImporter::translate_null_di_type(llvm::Type* type) {
@@ -941,12 +963,21 @@ ar::StructType* TypeWithDebugInfoImporter::translate_struct_di_type(
 
   const llvm::StructLayout* struct_layout =
       this->_llvm_data_layout.getStructLayout(struct_type);
+#if HAS_LLVM_9
   check_match(llvm::alignTo(di_type->getSizeInBits(),
                             static_cast< uint64_t >(
                                 struct_layout->getAlignment()) *
                                 8) == struct_layout->getSizeInBits(),
               "llvm DICompositeType and llvm structure type have a different "
               "bit-width");
+#else
+  check_match(llvm::alignTo(di_type->getSizeInBits(),
+                            static_cast< uint64_t >(
+                                struct_layout->getAlignment().value()) *
+                                8) == struct_layout->getSizeInBits(),
+              "llvm DICompositeType and llvm structure type have a different "
+              "bit-width");
+#endif
 
   // Structures can be recursive, so create it now, with an empty layout
   ar::StructType* ar_type =
@@ -994,8 +1025,13 @@ ar::StructType* TypeWithDebugInfoImporter::translate_struct_di_type(
     // llvm struct member
     llvm::Type* element_type = struct_type->getElementType(i);
     ar::ZNumber element_offset_bytes(struct_layout->getElementOffset(i));
+#if HAS_LLVM_9
     ar::ZNumber element_size_bytes(
         this->_llvm_data_layout.getTypeStoreSize(element_type));
+#else
+    ar::ZNumber element_size_bytes(
+        this->_llvm_data_layout.getTypeStoreSize(element_type).getFixedSize());
+#endif
 
     // Find matching debug info
     di_matching_members.clear();
@@ -1186,12 +1222,21 @@ ar::Type* TypeWithDebugInfoImporter::translate_union_di_type(
 
   const llvm::StructLayout* struct_layout =
       this->_llvm_data_layout.getStructLayout(struct_type);
+#if HAS_LLVM_9
   check_match(llvm::alignTo(di_type->getSizeInBits(),
                             static_cast< uint64_t >(
                                 struct_layout->getAlignment()) *
                                 8) == struct_layout->getSizeInBits(),
               "llvm DICompositeType and llvm structure type have a different "
               "bit-width");
+#else
+  check_match(llvm::alignTo(di_type->getSizeInBits(),
+                            static_cast< uint64_t >(
+                                struct_layout->getAlignment().value()) *
+                                8) == struct_layout->getSizeInBits(),
+              "llvm DICompositeType and llvm structure type have a different "
+              "bit-width");
+#endif
 
   // Structures can be recursive, so create it now, with an empty layout
   ar::StructType* ar_type =


### PR DESCRIPTION
Hi @arthaud, 

This PR is very naive version for supporting LLVM 11. IMHO, you have wanted to separate IKOS and LLVM layers for various reasons. In that sense, I think this patch is not enough for your intention. So I would like to need your feedbacks to update it in a right way. I also think this patch should be updated docs and other parts likewise your previous commit(LLVM 9).

Anyway, I passed all test cases on "make check", expected #78 .