### PR TITLE
Upgrade to LLVM 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
   apt:
     update: true
     sources:
-    - sourceline: "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main"
+    - sourceline: "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main"
       key_url: "https://apt.llvm.org/llvm-snapshot.gpg.key"
     packages:
     - gcc
@@ -23,10 +23,10 @@ addons:
     - libtbb-dev
     - libz-dev
     - libedit-dev
-    - llvm-9
-    - llvm-9-dev
-    - llvm-9-tools
-    - clang-9
+    - llvm-10
+    - llvm-10-dev
+    - llvm-10-tools
+    - clang-10
   homebrew:
     update: true
     taps: nasa-sw-vnv/core
@@ -40,7 +40,7 @@ addons:
 script:
   - mkdir build
   - cd build
-  - if [ $TRAVIS_OS_NAME == linux ]; then cmake -DCMAKE_BUILD_TYPE="Debug" -DLLVM_CONFIG_EXECUTABLE="/usr/lib/llvm-9/bin/llvm-config" ..; fi
+  - if [ $TRAVIS_OS_NAME == linux ]; then cmake -DCMAKE_BUILD_TYPE="Debug" -DLLVM_CONFIG_EXECUTABLE="/usr/lib/llvm-10/bin/llvm-config" ..; fi
   - if [ $TRAVIS_OS_NAME == osx ]; then cmake -DCMAKE_BUILD_TYPE="Debug" -DLLVM_CONFIG_EXECUTABLE="/usr/local/opt/llvm/bin/llvm-config" ..; fi
   - make
   - make install

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To build and run the analyzer, you will need the following dependencies:
 * Python 2 >= 2.7.3 or Python 3 >= 3.3
 * SQLite >= 3.6.20
 * TBB >= 2
-* LLVM and Clang 9.0.x
+* LLVM and Clang 10.0.x
 * (Optional) APRON >= 0.9.10
 * (Optional) Pygments
 

--- a/analyzer/CMakeLists.txt
+++ b/analyzer/CMakeLists.txt
@@ -122,8 +122,8 @@ include_directories(${FRONTEND_LLVM_INCLUDE_DIR})
 find_package(LLVM REQUIRED)
 include_directories(SYSTEM ${LLVM_INCLUDE_DIR})
 
-if ((LLVM_VERSION VERSION_LESS "9") OR (NOT (LLVM_VERSION VERSION_LESS "10")))
-  message(FATAL_ERROR "LLVM 9 is required.")
+if ((LLVM_VERSION VERSION_LESS "10") OR (NOT (LLVM_VERSION VERSION_LESS "11")))
+  message(FATAL_ERROR "LLVM 10 is required.")
 endif()
 
 # Add path to llvm cmake modules

--- a/analyzer/include/ikos/analyzer/json/json.hpp
+++ b/analyzer/include/ikos/analyzer/json/json.hpp
@@ -45,6 +45,8 @@
 
 #include <string>
 
+#include <llvm/ADT/StringRef.h>
+
 #include <ikos/analyzer/support/number.hpp>
 
 namespace ikos {
@@ -172,6 +174,11 @@ public:
 /// \brief Convert strings to JsonString
 inline JsonString to_json(std::string s) {
   return JsonString(std::move(s));
+}
+
+/// \brief Convert strings to JsonString
+inline JsonString to_json(llvm::StringRef s) {
+  return JsonString(std::move(s.str()));
 }
 
 /// \brief Convert strings to JsonString

--- a/analyzer/include/ikos/analyzer/util/demangle.hpp
+++ b/analyzer/include/ikos/analyzer/util/demangle.hpp
@@ -53,6 +53,8 @@
 #include <boost/core/demangle.hpp>
 #endif
 
+#include <llvm/ADT/StringRef.h>
+
 #include <ikos/analyzer/support/string_ref.hpp>
 
 namespace ikos {
@@ -93,6 +95,12 @@ inline std::string demangle(const std::string& name) {
 inline std::string demangle(StringRef name) {
   // boost::core::demangle requires a null-terminated string
   return demangle(name.to_string());
+}
+
+/// \brief Return the demangled symbol name, or name if it is not mangled
+inline std::string demangle(llvm::StringRef name) {
+  // boost::core::demangle requires a null-terminated string
+  return demangle(name.str());
 }
 
 } // end namespace analyzer

--- a/analyzer/src/database/table/memory_locations.cpp
+++ b/analyzer/src/database/table/memory_locations.cpp
@@ -169,7 +169,7 @@ JsonDict MemoryLocationsTable::info(MemoryLocation* mem_loc) {
 
     // Last chance, use llvm variable name
     if (llvm_gv->hasName()) {
-      std::string name = llvm_gv->getName();
+      std::string name = llvm_gv->getName().str();
       if (is_mangled(name)) {
         return {{"name", name}, {"demangle", demangle(name)}};
       } else {

--- a/analyzer/src/database/table/operands.cpp
+++ b/analyzer/src/database/table/operands.cpp
@@ -46,6 +46,7 @@
 
 #include <boost/container/flat_set.hpp>
 
+#include <llvm/ADT/SmallString.h>
 #include <llvm/IR/DebugInfoMetadata.h>
 #include <llvm/IR/InlineAsm.h>
 #include <llvm/IR/Instructions.h>
@@ -163,7 +164,7 @@ std::string to_string(const llvm::APInt& n) {
 std::string to_string(const llvm::APFloat& f) {
   llvm::SmallString< 16 > str;
   f.toString(str, /*FormatPrecision=*/0, /*FormatMaxPadding=*/0);
-  return str.str();
+  return str.str().str();
 }
 
 /// \brief Return the hexadecimal character for the given number
@@ -359,7 +360,7 @@ std::string repr(llvm::Type* type, TypeSet seen) {
       llvm::StringRef name = struct_type->getName();
       name.consume_front("struct.");
       name.consume_front("class.");
-      return name;
+      return name.str();
     }
 
     if (struct_type->isOpaque()) {
@@ -701,7 +702,7 @@ ReprResult repr(llvm::Value* value, ValueSet seen) {
       llvm::StringRef name = di_var->getName();
 
       if (!name.empty()) {
-        return ReprResult{name, pointee_type(di_type)};
+        return ReprResult{name.str(), pointee_type(di_type)};
       }
     }
   }

--- a/doc/install/CENTOS_6.10.md
+++ b/doc/install/CENTOS_6.10.md
@@ -78,7 +78,7 @@ After installation, the install directory will contain the following structure:
 │   ├── include
 │   ├── lib
 │   └── share
-├── llvm-9.0.0
+├── llvm-10.0.0
 │   ├── bin
 │   ├── include
 │   ├── lib

--- a/doc/install/CENTOS_7.6.md
+++ b/doc/install/CENTOS_7.6.md
@@ -74,7 +74,7 @@ After installation, the install directory will contain the following structure:
 │   ├── include
 │   ├── lib
 │   └── share
-├── llvm-9.0.0
+├── llvm-10.0.0
 │   ├── bin
 │   ├── include
 │   ├── lib

--- a/doc/install/DEBIAN_10.md
+++ b/doc/install/DEBIAN_10.md
@@ -13,7 +13,7 @@ $ sudo apt-get upgrade
 Now, you will need to add the LLVM repository to your apt `sources.list`:
 
 ```
-$ echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-9 main" | sudo tee -a /etc/apt/sources.list
+$ echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-10 main" | sudo tee -a /etc/apt/sources.list
 ```
 
 You also need to trust the LLVM repository key:
@@ -28,7 +28,7 @@ Then, run the following commands:
 $ sudo apt-get update
 $ sudo apt-get install gcc g++ cmake libgmp-dev libboost-dev libboost-filesystem-dev \
     libboost-thread-dev libboost-test-dev python python-pygments libsqlite3-dev libtbb-dev \
-    libz-dev libedit-dev llvm-9 llvm-9-dev llvm-9-tools clang-9
+    libz-dev libedit-dev llvm-10 llvm-10-dev llvm-10-tools clang-10
 ```
 
 When running cmake to build IKOS, you will need to define `LLVM_CONFIG_EXECUTABLE`:
@@ -36,7 +36,7 @@ When running cmake to build IKOS, you will need to define `LLVM_CONFIG_EXECUTABL
 ```
 $ cmake \
     -DCMAKE_INSTALL_PREFIX="/path/to/ikos-install-directory" \
-    -DLLVM_CONFIG_EXECUTABLE="/usr/lib/llvm-9/bin/llvm-config" \
+    -DLLVM_CONFIG_EXECUTABLE="/usr/lib/llvm-10/bin/llvm-config" \
     ..
 ```
 

--- a/doc/install/DEBIAN_9.md
+++ b/doc/install/DEBIAN_9.md
@@ -13,7 +13,7 @@ $ sudo apt-get upgrade
 Now, you will need to add the LLVM repository to your apt `sources.list`:
 
 ```
-$ echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch-9 main" | sudo tee -a /etc/apt/sources.list
+$ echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch-10 main" | sudo tee -a /etc/apt/sources.list
 ```
 
 You also need to trust the LLVM repository key:
@@ -28,7 +28,7 @@ Then, run the following commands:
 $ sudo apt-get update
 $ sudo apt-get install gcc g++ cmake libgmp-dev libboost-dev libboost-filesystem-dev \
     libboost-thread-dev libboost-test-dev python python-pygments libsqlite3-dev libtbb-dev \
-    libz-dev libedit-dev llvm-9 llvm-9-dev llvm-9-tools clang-9
+    libz-dev libedit-dev llvm-10 llvm-10-dev llvm-10-tools clang-10
 ```
 
 When running cmake to build IKOS, you will need to define `LLVM_CONFIG_EXECUTABLE`:
@@ -36,7 +36,7 @@ When running cmake to build IKOS, you will need to define `LLVM_CONFIG_EXECUTABL
 ```
 $ cmake \
     -DCMAKE_INSTALL_PREFIX="/path/to/ikos-install-directory" \
-    -DLLVM_CONFIG_EXECUTABLE="/usr/lib/llvm-9/bin/llvm-config" \
+    -DLLVM_CONFIG_EXECUTABLE="/usr/lib/llvm-10/bin/llvm-config" \
     ..
 ```
 

--- a/doc/install/FEDORA_29.md
+++ b/doc/install/FEDORA_29.md
@@ -50,7 +50,7 @@ After installation, the install directory will contain the following structure:
 │   ├── include
 │   ├── lib
 │   └── share
-└── llvm-9.0.0
+└── llvm-10.0.0
     ├── bin
     ├── include
     ├── lib

--- a/doc/install/FEDORA_30.md
+++ b/doc/install/FEDORA_30.md
@@ -50,7 +50,7 @@ After installation, the install directory will contain the following structure:
 │   ├── include
 │   ├── lib
 │   └── share
-└── llvm-9.0.0
+└── llvm-10.0.0
     ├── bin
     ├── include
     ├── lib

--- a/doc/install/RHEL_6.10.md
+++ b/doc/install/RHEL_6.10.md
@@ -73,7 +73,7 @@ After installation, the install directory will contain the following structure:
 │   ├── include
 │   ├── lib
 │   └── share
-├── llvm-9.0.0
+├── llvm-10.0.0
 │   ├── bin
 │   ├── include
 │   ├── lib

--- a/doc/install/RHEL_7.7.md
+++ b/doc/install/RHEL_7.7.md
@@ -69,7 +69,7 @@ After installation, the install directory will contain the following structure:
 │   ├── include
 │   ├── lib
 │   └── share
-├── llvm-9.0.0
+├── llvm-10.0.0
 │   ├── bin
 │   ├── include
 │   ├── lib

--- a/doc/install/ROOTLESS.md
+++ b/doc/install/ROOTLESS.md
@@ -67,7 +67,7 @@ After installation, the install directory will contain the following structure:
 │   ├── include
 │   ├── lib
 │   └── share
-└── llvm-9.0.0
+└── llvm-10.0.0
     ├── bin
     ├── include
     ├── lib

--- a/doc/install/UBUNTU_16.04.md
+++ b/doc/install/UBUNTU_16.04.md
@@ -13,7 +13,7 @@ $ sudo apt-get upgrade
 Now, you will need to add the LLVM repository to your apt `sources.list`:
 
 ```
-$ echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main" | sudo tee -a /etc/apt/sources.list
+$ echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main" | sudo tee -a /etc/apt/sources.list
 ```
 
 You also need to trust the LLVM repository key:
@@ -28,7 +28,7 @@ Then, run the following commands:
 $ sudo apt-get update
 $ sudo apt-get install gcc g++ cmake libgmp-dev libboost-dev libboost-filesystem-dev \
     libboost-thread-dev libboost-test-dev python python-pygments libsqlite3-dev libtbb-dev \
-    libz-dev libedit-dev llvm-9 llvm-9-dev llvm-9-tools clang-9
+    libz-dev libedit-dev llvm-10 llvm-10-dev llvm-10-tools clang-10
 ```
 
 When running cmake to build IKOS, you will need to define `LLVM_CONFIG_EXECUTABLE`:
@@ -36,7 +36,7 @@ When running cmake to build IKOS, you will need to define `LLVM_CONFIG_EXECUTABL
 ```
 $ cmake \
     -DCMAKE_INSTALL_PREFIX="/path/to/ikos-install-directory" \
-    -DLLVM_CONFIG_EXECUTABLE="/usr/lib/llvm-9/bin/llvm-config" \
+    -DLLVM_CONFIG_EXECUTABLE="/usr/lib/llvm-10/bin/llvm-config" \
     ..
 ```
 

--- a/doc/install/UBUNTU_18.04.md
+++ b/doc/install/UBUNTU_18.04.md
@@ -13,7 +13,7 @@ $ sudo apt-get upgrade
 Now, you will need to add the LLVM repository to your apt `sources.list`:
 
 ```
-$ echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main" | sudo tee -a /etc/apt/sources.list
+$ echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main" | sudo tee -a /etc/apt/sources.list
 ```
 
 You also need to trust the LLVM repository key:
@@ -28,7 +28,7 @@ Then, run the following commands:
 $ sudo apt-get update
 $ sudo apt-get install gcc g++ cmake libgmp-dev libboost-dev libboost-filesystem-dev \
     libboost-thread-dev libboost-test-dev python python-pygments libsqlite3-dev libtbb-dev \
-    libz-dev libedit-dev llvm-9 llvm-9-dev llvm-9-tools clang-9
+    libz-dev libedit-dev llvm-10 llvm-10-dev llvm-10-tools clang-10
 ```
 
 When running cmake to build IKOS, you will need to define `LLVM_CONFIG_EXECUTABLE`:
@@ -36,7 +36,7 @@ When running cmake to build IKOS, you will need to define `LLVM_CONFIG_EXECUTABL
 ```
 $ cmake \
     -DCMAKE_INSTALL_PREFIX="/path/to/ikos-install-directory" \
-    -DLLVM_CONFIG_EXECUTABLE="/usr/lib/llvm-9/bin/llvm-config" \
+    -DLLVM_CONFIG_EXECUTABLE="/usr/lib/llvm-10/bin/llvm-config" \
     ..
 ```
 

--- a/doc/install/UBUNTU_19.04.md
+++ b/doc/install/UBUNTU_19.04.md
@@ -13,7 +13,7 @@ $ sudo apt-get upgrade
 Now, you will need to add the LLVM repository to your apt `sources.list`:
 
 ```
-$ echo "deb http://apt.llvm.org/disco/ llvm-toolchain-disco-9 main" | sudo tee -a /etc/apt/sources.list
+$ echo "deb http://apt.llvm.org/disco/ llvm-toolchain-disco-10 main" | sudo tee -a /etc/apt/sources.list
 ```
 
 You also need to trust the LLVM repository key:
@@ -28,7 +28,7 @@ Then, run the following commands:
 $ sudo apt-get update
 $ sudo apt-get install gcc g++ cmake libgmp-dev libboost-dev libboost-filesystem-dev \
     libboost-thread-dev libboost-test-dev python python-pygments libsqlite3-dev libtbb-dev \
-    libz-dev libedit-dev llvm-9 llvm-9-dev llvm-9-tools clang-9
+    libz-dev libedit-dev llvm-10 llvm-10-dev llvm-10-tools clang-10
 ```
 
 When running cmake to build IKOS, you will need to define `LLVM_CONFIG_EXECUTABLE`:
@@ -36,7 +36,7 @@ When running cmake to build IKOS, you will need to define `LLVM_CONFIG_EXECUTABL
 ```
 $ cmake \
     -DCMAKE_INSTALL_PREFIX="/path/to/ikos-install-directory" \
-    -DLLVM_CONFIG_EXECUTABLE="/usr/lib/llvm-9/bin/llvm-config" \
+    -DLLVM_CONFIG_EXECUTABLE="/usr/lib/llvm-10/bin/llvm-config" \
     ..
 ```
 

--- a/frontend/llvm/CMakeLists.txt
+++ b/frontend/llvm/CMakeLists.txt
@@ -103,8 +103,8 @@ include_directories(${AR_INCLUDE_DIR})
 find_package(LLVM REQUIRED)
 include_directories(SYSTEM ${LLVM_INCLUDE_DIR})
 
-if ((LLVM_VERSION VERSION_LESS "9") OR (NOT (LLVM_VERSION VERSION_LESS "10")))
-  message(FATAL_ERROR "LLVM 9 is required.")
+if ((LLVM_VERSION VERSION_LESS "10") OR (NOT (LLVM_VERSION VERSION_LESS "11")))
+  message(FATAL_ERROR "LLVM 10 is required.")
 endif()
 
 # Add path to llvm cmake modules

--- a/frontend/llvm/README.md
+++ b/frontend/llvm/README.md
@@ -24,7 +24,7 @@ To build IKOS LLVM Frontend, you will need the following dependencies:
 * CMake >= 3.4.3
 * GMP >= 4.3.1
 * Boost >= 1.55
-* LLVM 9.0.x
+* LLVM 10.0.x
 * IKOS Core
 * IKOS AR
 

--- a/frontend/llvm/src/ikos_pp.cpp
+++ b/frontend/llvm/src/ikos_pp.cpp
@@ -52,6 +52,7 @@
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Verifier.h>
 #include <llvm/IRReader/IRReader.h>
+#include <llvm/InitializePasses.h>
 #include <llvm/LinkAllPasses.h>
 #include <llvm/Support/CommandLine.h>
 #include <llvm/Support/Debug.h>

--- a/frontend/llvm/src/import/bundle.cpp
+++ b/frontend/llvm/src/import/bundle.cpp
@@ -71,7 +71,7 @@ ar::GlobalVariable* BundleImporter::translate_global_variable(
 
   std::string name;
   if (gv->hasName()) {
-    name = gv->getName();
+    name = gv->getName().str();
   } else {
     name = this->_bundle->find_available_name("__unnamed_global_var");
   }

--- a/frontend/llvm/src/import/data_layout.cpp
+++ b/frontend/llvm/src/import/data_layout.cpp
@@ -62,9 +62,10 @@ std::unique_ptr< ar::DataLayout > translate_data_layout(
       llvm_data_layout.isLittleEndian() ? ar::LittleEndian : ar::BigEndian;
 
   // Translate pointer size and alignments
-  ar::DataLayoutInfo pointers(llvm_data_layout.getPointerSizeInBits(),
-                              llvm_data_layout.getPointerABIAlignment(0),
-                              llvm_data_layout.getPointerPrefAlignment());
+  ar::DataLayoutInfo
+      pointers(llvm_data_layout.getPointerSizeInBits(),
+               llvm_data_layout.getPointerABIAlignment(0).value(),
+               llvm_data_layout.getPointerPrefAlignment().value());
 
   // Create ar::DataLayout
   std::unique_ptr< ar::DataLayout > ar_data_layout =

--- a/frontend/llvm/src/import/function.cpp
+++ b/frontend/llvm/src/import/function.cpp
@@ -1535,7 +1535,8 @@ ar::IntegerConstant* FunctionImporter::translate_indexes(
     } else if (auto seq_type =
                    llvm::dyn_cast< llvm::SequentialType >(indexed_type)) {
       ar::ZNumber element_size(
-          this->_llvm_data_layout.getTypeAllocSize(seq_type->getElementType()));
+          this->_llvm_data_layout.getTypeAllocSize(seq_type->getElementType())
+              .getFixedSize());
       offset += element_size * idx;
     } else {
       throw ImportError("unsupported operand to llvm extractvalue");
@@ -1570,8 +1571,10 @@ void FunctionImporter::translate_extractelement(
     throw ImportError("unsupported operand to llvm extractelement");
   }
   auto size_type = ar::IntegerType::size_type(this->_bundle);
-  ar::ZNumber element_size(this->_llvm_data_layout.getTypeAllocSize(
-      inst->getVectorOperandType()->getElementType()));
+  ar::ZNumber element_size(
+      this->_llvm_data_layout
+          .getTypeAllocSize(inst->getVectorOperandType()->getElementType())
+          .getFixedSize());
   ar::ZNumber offset_value = index->getZExtValue() * element_size;
   auto offset = ar::IntegerConstant::get(this->_context,
                                          size_type,
@@ -1602,8 +1605,10 @@ void FunctionImporter::translate_insertelement(
     throw ImportError("unsupported operand to llvm insertelement");
   }
   auto size_type = ar::IntegerType::size_type(this->_bundle);
-  ar::ZNumber element_size(this->_llvm_data_layout.getTypeAllocSize(
-      inst->getType()->getElementType()));
+  ar::ZNumber element_size(
+      this->_llvm_data_layout
+          .getTypeAllocSize(inst->getType()->getElementType())
+          .getFixedSize());
   ar::ZNumber offset_value = index->getZExtValue() * element_size;
   auto offset = ar::IntegerConstant::get(this->_context,
                                          size_type,

--- a/frontend/llvm/src/import/type.cpp
+++ b/frontend/llvm/src/import/type.cpp
@@ -138,10 +138,12 @@ void TypeWithSignImporter::sanity_check_size(llvm::Type* llvm_type,
     return;
   }
 
-  check_import(this->_llvm_data_layout.getTypeSizeInBits(llvm_type) >=
+  check_import(this->_llvm_data_layout.getTypeSizeInBits(llvm_type)
+                       .getFixedSize() >=
                    this->_ar_data_layout.size_in_bits(ar_type),
                "llvm type size in bits is smaller than ar type size");
-  check_import(this->_llvm_data_layout.getTypeAllocSize(llvm_type) ==
+  check_import(this->_llvm_data_layout.getTypeAllocSize(llvm_type)
+                       .getFixedSize() ==
                    this->_ar_data_layout.alloc_size_in_bytes(ar_type),
                "llvm type and ar type alloc size are different");
 }
@@ -410,10 +412,12 @@ void TypeWithDebugInfoImporter::sanity_check_size(llvm::Type* llvm_type,
     return;
   }
 
-  check_import(this->_llvm_data_layout.getTypeSizeInBits(llvm_type) >=
+  check_import(this->_llvm_data_layout.getTypeSizeInBits(llvm_type)
+                       .getFixedSize() >=
                    this->_ar_data_layout.size_in_bits(ar_type),
                "llvm type size in bits is smaller than ar type size");
-  check_import(this->_llvm_data_layout.getTypeAllocSize(llvm_type) ==
+  check_import(this->_llvm_data_layout.getTypeAllocSize(llvm_type)
+                       .getFixedSize() ==
                    this->_ar_data_layout.alloc_size_in_bytes(ar_type),
                "llvm type and ar type alloc size are different");
 }
@@ -943,7 +947,7 @@ ar::StructType* TypeWithDebugInfoImporter::translate_struct_di_type(
       this->_llvm_data_layout.getStructLayout(struct_type);
   check_match(llvm::alignTo(di_type->getSizeInBits(),
                             static_cast< uint64_t >(
-                                struct_layout->getAlignment()) *
+                                struct_layout->getAlignment().value()) *
                                 8) == struct_layout->getSizeInBits(),
               "llvm DICompositeType and llvm structure type have a different "
               "bit-width");
@@ -995,7 +999,7 @@ ar::StructType* TypeWithDebugInfoImporter::translate_struct_di_type(
     llvm::Type* element_type = struct_type->getElementType(i);
     ar::ZNumber element_offset_bytes(struct_layout->getElementOffset(i));
     ar::ZNumber element_size_bytes(
-        this->_llvm_data_layout.getTypeStoreSize(element_type));
+        this->_llvm_data_layout.getTypeStoreSize(element_type).getFixedSize());
 
     // Find matching debug info
     di_matching_members.clear();
@@ -1188,7 +1192,7 @@ ar::Type* TypeWithDebugInfoImporter::translate_union_di_type(
       this->_llvm_data_layout.getStructLayout(struct_type);
   check_match(llvm::alignTo(di_type->getSizeInBits(),
                             static_cast< uint64_t >(
-                                struct_layout->getAlignment()) *
+                                struct_layout->getAlignment().value()) *
                                 8) == struct_layout->getSizeInBits(),
               "llvm DICompositeType and llvm structure type have a different "
               "bit-width");

--- a/frontend/llvm/test/regression/import/aggressive_optimization/aggregate-in-reg-1.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/aggregate-in-reg-1.ll
@@ -144,14 +144,14 @@ attributes #3 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "aggregate-in-reg-1.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 19, type: !9, scopeLine: 19, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11, !12}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/aggregate-in-reg-2.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/aggregate-in-reg-2.ll
@@ -48,14 +48,14 @@ attributes #2 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "aggregate-in-reg-2.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "f", linkageName: "_Z1ff", scope: !1, file: !1, line: 12, type: !9, scopeLine: 12, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !19}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/array-init.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/array-init.ll
@@ -12,7 +12,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 !llvm.module.flags = !{!16, !17, !18, !19}
 !llvm.ident = !{!20}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "array-init.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{!4}
@@ -32,4 +32,4 @@ target triple = "x86_64-apple-macosx10.14.0"
 !17 = !{i32 2, !"Debug Info Version", i32 3}
 !18 = !{i32 1, !"wchar_size", i32 4}
 !19 = !{i32 7, !"PIC Level", i32 2}
-!20 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!20 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/asm.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/asm.ll
@@ -34,14 +34,14 @@ attributes #2 = { nounwind readnone }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "asm.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !9, scopeLine: 3, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/atomic.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/atomic.ll
@@ -38,7 +38,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "x", scope: !2, file: !3, line: 1, type: !8, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, retainedTypes: !5, globals: !7, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, retainedTypes: !5, globals: !7, nameTableKind: GNU)
 !3 = !DIFile(filename: "atomic.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !4 = !{}
 !5 = !{!6}
@@ -51,7 +51,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !12 = !{i32 2, !"Debug Info Version", i32 3}
 !13 = !{i32 1, !"wchar_size", i32 4}
 !14 = !{i32 7, !"PIC Level", i32 2}
-!15 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!15 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !16 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 3, type: !17, scopeLine: 3, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !17 = !DISubroutineType(types: !5)
 !18 = !DILocation(line: 4, column: 5, scope: !16)

--- a/frontend/llvm/test/regression/import/aggressive_optimization/basic-loop.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/basic-loop.ll
@@ -32,7 +32,7 @@ attributes #1 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!10, !11, !12, !13}
 !llvm.ident = !{!14}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "basic-loop.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{!4}
@@ -46,7 +46,7 @@ attributes #1 = { nounwind readnone speculatable }
 !11 = !{i32 2, !"Debug Info Version", i32 3}
 !12 = !{i32 1, !"wchar_size", i32 4}
 !13 = !{i32 7, !"PIC Level", i32 2}
-!14 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!14 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !15 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !16, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !16 = !DISubroutineType(types: !17)
 !17 = !{!18, !18, !19}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/bit-field-1.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/bit-field-1.ll
@@ -24,14 +24,14 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "bit-field-1.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 8, type: !9, scopeLine: 8, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/bit-field-2.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/bit-field-2.ll
@@ -12,7 +12,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 !llvm.module.flags = !{!14, !15, !16, !17}
 !llvm.ident = !{!18}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "bit-field-2.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{!4}
@@ -30,4 +30,4 @@ target triple = "x86_64-apple-macosx10.14.0"
 !15 = !{i32 2, !"Debug Info Version", i32 3}
 !16 = !{i32 1, !"wchar_size", i32 4}
 !17 = !{i32 7, !"PIC Level", i32 2}
-!18 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!18 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/bitwise-cond-1.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/bitwise-cond-1.ll
@@ -12,11 +12,11 @@ target triple = "x86_64-apple-macosx10.14.0"
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "bitwise-cond-1.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/bitwise-cond-2.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/bitwise-cond-2.ll
@@ -12,7 +12,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 !llvm.module.flags = !{!7, !8, !9, !10}
 !llvm.ident = !{!11}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "bitwise-cond-2.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{!4}
@@ -23,4 +23,4 @@ target triple = "x86_64-apple-macosx10.14.0"
 !8 = !{i32 2, !"Debug Info Version", i32 3}
 !9 = !{i32 1, !"wchar_size", i32 4}
 !10 = !{i32 7, !"PIC Level", i32 2}
-!11 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!11 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/bitwise-op.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/bitwise-op.ll
@@ -31,14 +31,14 @@ attributes #1 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "bitwise-op.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 1, type: !9, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/bool-op-select.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/bool-op-select.ll
@@ -24,7 +24,7 @@ attributes #0 = { noinline norecurse nounwind ssp uwtable "correctly-rounded-div
 !llvm.module.flags = !{!7, !8, !9, !10}
 !llvm.ident = !{!11}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "bool-op-select.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{!4}
@@ -35,7 +35,7 @@ attributes #0 = { noinline norecurse nounwind ssp uwtable "correctly-rounded-div
 !8 = !{i32 2, !"Debug Info Version", i32 3}
 !9 = !{i32 1, !"wchar_size", i32 4}
 !10 = !{i32 7, !"PIC Level", i32 2}
-!11 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!11 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !12 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 10, type: !13, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !13 = !DISubroutineType(types: !14)
 !14 = !{!6}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/bool.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/bool.ll
@@ -24,7 +24,7 @@ attributes #0 = { noinline norecurse nounwind ssp uwtable "correctly-rounded-div
 !llvm.module.flags = !{!7, !8, !9, !10}
 !llvm.ident = !{!11}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "bool.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{!4}
@@ -35,7 +35,7 @@ attributes #0 = { noinline norecurse nounwind ssp uwtable "correctly-rounded-div
 !8 = !{i32 2, !"Debug Info Version", i32 3}
 !9 = !{i32 1, !"wchar_size", i32 4}
 !10 = !{i32 7, !"PIC Level", i32 2}
-!11 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!11 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !12 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 5, type: !13, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !13 = !DISubroutineType(types: !14)
 !14 = !{!15}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/branch-undef.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/branch-undef.ll
@@ -24,14 +24,14 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "branch-undef.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 1, type: !9, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/call-args.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/call-args.ll
@@ -45,14 +45,14 @@ attributes #1 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "call-args.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 1, type: !9, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/complex.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/complex.ll
@@ -30,14 +30,14 @@ attributes #1 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "complex.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !9, scopeLine: 3, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/constructors.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/constructors.ll
@@ -169,14 +169,14 @@ attributes #7 = { nounwind }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "constructors.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "f", linkageName: "_Z1fP6Vector", scope: !1, file: !1, line: 14, type: !9, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !12}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/empty-array-1.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/empty-array-1.ll
@@ -12,7 +12,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 !llvm.module.flags = !{!18, !19, !20, !21}
 !llvm.ident = !{!22}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "empty-array-1.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{!4}
@@ -34,4 +34,4 @@ target triple = "x86_64-apple-macosx10.14.0"
 !19 = !{i32 2, !"Debug Info Version", i32 3}
 !20 = !{i32 1, !"wchar_size", i32 4}
 !21 = !{i32 7, !"PIC Level", i32 2}
-!22 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!22 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/empty-array-2.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/empty-array-2.ll
@@ -12,7 +12,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 !llvm.module.flags = !{!17, !18, !19, !20}
 !llvm.ident = !{!21}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "empty-array-2.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{!4}
@@ -33,4 +33,4 @@ target triple = "x86_64-apple-macosx10.14.0"
 !18 = !{i32 2, !"Debug Info Version", i32 3}
 !19 = !{i32 1, !"wchar_size", i32 4}
 !20 = !{i32 7, !"PIC Level", i32 2}
-!21 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!21 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/empty-array-3.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/empty-array-3.ll
@@ -12,7 +12,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 !llvm.module.flags = !{!15, !16, !17, !18}
 !llvm.ident = !{!19}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "empty-array-3.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{!4}
@@ -31,4 +31,4 @@ target triple = "x86_64-apple-macosx10.14.0"
 !16 = !{i32 2, !"Debug Info Version", i32 3}
 !17 = !{i32 1, !"wchar_size", i32 4}
 !18 = !{i32 7, !"PIC Level", i32 2}
-!19 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!19 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/empty-function-body.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/empty-function-body.ll
@@ -12,11 +12,11 @@ target triple = "x86_64-apple-macosx10.14.0"
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "empty-function-body.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/file-intrinsics.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/file-intrinsics.ll
@@ -124,14 +124,14 @@ attributes #3 = { nounwind }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "file-intrinsics.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !9, scopeLine: 3, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/flexible-array-member.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/flexible-array-member.ll
@@ -24,7 +24,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !llvm.module.flags = !{!15, !16, !17, !18}
 !llvm.ident = !{!19}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "flexible-array-member.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{!4}
@@ -43,7 +43,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !16 = !{i32 2, !"Debug Info Version", i32 3}
 !17 = !{i32 1, !"wchar_size", i32 4}
 !18 = !{i32 7, !"PIC Level", i32 2}
-!19 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!19 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !20 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 8, type: !21, scopeLine: 8, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !21 = !DISubroutineType(types: !22)
 !22 = !{!9}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/gv-init.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/gv-init.ll
@@ -87,7 +87,7 @@ attributes #1 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!19, !20, !21, !22}
 !llvm.ident = !{!23}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "gv-init.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{!4, !10, !12, !17}
@@ -110,7 +110,7 @@ attributes #1 = { nounwind readnone speculatable }
 !20 = !{i32 2, !"Debug Info Version", i32 3}
 !21 = !{i32 1, !"wchar_size", i32 4}
 !22 = !{i32 7, !"PIC Level", i32 2}
-!23 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!23 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !24 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 7, type: !25, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !25 = !DISubroutineType(types: !26)
 !26 = !{!7, !7, !27}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/linked-list.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/linked-list.ll
@@ -30,7 +30,7 @@ attributes #1 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!12, !13, !14, !15}
 !llvm.ident = !{!16}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "linked-list.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{!4}
@@ -46,7 +46,7 @@ attributes #1 = { nounwind readnone speculatable }
 !13 = !{i32 2, !"Debug Info Version", i32 3}
 !14 = !{i32 1, !"wchar_size", i32 4}
 !15 = !{i32 7, !"PIC Level", i32 2}
-!16 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!16 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !17 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 8, type: !18, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !18 = !DISubroutineType(types: !19)
 !19 = !{!9, !9, !20}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/local-array-1.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/local-array-1.ll
@@ -71,14 +71,14 @@ attributes #1 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "local-array-1.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 6, type: !9, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11, !12}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/local-array-2.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/local-array-2.ll
@@ -116,14 +116,14 @@ attributes #2 = { argmemonly nounwind }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "local-array-2.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 4, type: !9, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11, !13}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/mem-intrinsics.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/mem-intrinsics.ll
@@ -38,7 +38,7 @@ attributes #2 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!6, !7, !8, !9}
 !llvm.ident = !{!10}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, retainedTypes: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, retainedTypes: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "mem-intrinsics.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{!4}
@@ -48,7 +48,7 @@ attributes #2 = { nounwind readnone speculatable }
 !7 = !{i32 2, !"Debug Info Version", i32 3}
 !8 = !{i32 1, !"wchar_size", i32 4}
 !9 = !{i32 7, !"PIC Level", i32 2}
-!10 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!10 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !11 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 8, type: !12, scopeLine: 8, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !12 = !DISubroutineType(types: !13)
 !13 = !{!5}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/multiple-inheritance.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/multiple-inheritance.ll
@@ -24,7 +24,7 @@ attributes #0 = { noinline norecurse nounwind ssp uwtable "correctly-rounded-div
 !llvm.module.flags = !{!30, !31, !32, !33}
 !llvm.ident = !{!34}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "multiple-inheritance.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{!4}
@@ -58,7 +58,7 @@ attributes #0 = { noinline norecurse nounwind ssp uwtable "correctly-rounded-div
 !31 = !{i32 2, !"Debug Info Version", i32 3}
 !32 = !{i32 1, !"wchar_size", i32 4}
 !33 = !{i32 7, !"PIC Level", i32 2}
-!34 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!34 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !35 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 23, type: !36, scopeLine: 23, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !36 = !DISubroutineType(types: !37)
 !37 = !{!12}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/nested-struct.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/nested-struct.ll
@@ -30,14 +30,14 @@ attributes #1 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "nested-struct.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 7, type: !9, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11, !12}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/noexcept.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/noexcept.ll
@@ -12,11 +12,11 @@ target triple = "x86_64-apple-macosx10.14.0"
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "noexcept.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/non-term-1.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/non-term-1.ll
@@ -39,14 +39,14 @@ attributes #3 = { noreturn nounwind }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "non-term-1.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !9, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11, !12}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/non-term-2.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/non-term-2.ll
@@ -28,14 +28,14 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "non-term-2.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !9, scopeLine: 3, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/nullptr.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/nullptr.ll
@@ -42,14 +42,14 @@ attributes #2 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "nullptr.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "f", linkageName: "_Z1fDn", scope: !1, file: !1, line: 1, type: !9, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !12}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/opaque-struct.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/opaque-struct.ll
@@ -24,7 +24,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !llvm.module.flags = !{!15, !16, !17, !18}
 !llvm.ident = !{!19}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "opaque-struct.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{!4}
@@ -43,7 +43,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !16 = !{i32 2, !"Debug Info Version", i32 3}
 !17 = !{i32 1, !"wchar_size", i32 4}
 !18 = !{i32 7, !"PIC Level", i32 2}
-!19 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!19 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !20 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 12, type: !21, scopeLine: 12, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !21 = !DISubroutineType(types: !22)
 !22 = !{!11}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/phi-1.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/phi-1.ll
@@ -32,7 +32,7 @@ attributes #1 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!10, !11, !12, !13}
 !llvm.ident = !{!14}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "phi-1.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{!4}
@@ -46,7 +46,7 @@ attributes #1 = { nounwind readnone speculatable }
 !11 = !{i32 2, !"Debug Info Version", i32 3}
 !12 = !{i32 1, !"wchar_size", i32 4}
 !13 = !{i32 7, !"PIC Level", i32 2}
-!14 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!14 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !15 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !16, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !16 = !DISubroutineType(types: !17)
 !17 = !{!18, !18, !19}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/phi-2.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/phi-2.ll
@@ -154,14 +154,14 @@ attributes #1 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "phi-2.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 18, type: !9, scopeLine: 18, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11, !12}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/phi-3.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/phi-3.ll
@@ -233,14 +233,14 @@ attributes #3 = { nounwind }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "phi-3.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !12, !12, !12}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/phi-4.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/phi-4.ll
@@ -32,14 +32,14 @@ attributes #1 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "phi-4.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 1, type: !9, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11, !12}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/pod-types.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/pod-types.ll
@@ -38,7 +38,7 @@ attributes #1 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!30, !31, !32, !33}
 !llvm.ident = !{!34}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "pod-types.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{!4, !7, !10, !13, !16, !20, !23}
@@ -72,7 +72,7 @@ attributes #1 = { nounwind readnone speculatable }
 !31 = !{i32 2, !"Debug Info Version", i32 3}
 !32 = !{i32 1, !"wchar_size", i32 4}
 !33 = !{i32 7, !"PIC Level", i32 2}
-!34 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!34 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !35 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 17, type: !36, scopeLine: 17, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !36 = !DISubroutineType(types: !37)
 !37 = !{!19, !19, !38}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/pointer-arithmetic.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/pointer-arithmetic.ll
@@ -39,7 +39,7 @@ attributes #1 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-
 !llvm.module.flags = !{!28, !29, !30, !31}
 !llvm.ident = !{!32}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "pointer-arithmetic.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{!4, !8, !16, !25}
@@ -71,7 +71,7 @@ attributes #1 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-
 !29 = !{i32 2, !"Debug Info Version", i32 3}
 !30 = !{i32 1, !"wchar_size", i32 4}
 !31 = !{i32 7, !"PIC Level", i32 2}
-!32 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!32 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !33 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 21, type: !34, scopeLine: 21, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !34 = !DISubroutineType(types: !35)
 !35 = !{!22}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/ptr-to-int.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/ptr-to-int.ll
@@ -12,7 +12,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 !llvm.module.flags = !{!9, !10, !11, !12}
 !llvm.ident = !{!13}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "ptr-to-int.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{!4}
@@ -25,4 +25,4 @@ target triple = "x86_64-apple-macosx10.14.0"
 !10 = !{i32 2, !"Debug Info Version", i32 3}
 !11 = !{i32 1, !"wchar_size", i32 4}
 !12 = !{i32 7, !"PIC Level", i32 2}
-!13 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!13 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/reference.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/reference.ll
@@ -53,14 +53,14 @@ attributes #2 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "reference.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "f", linkageName: "_Z1fRi", scope: !1, file: !1, line: 1, type: !9, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{null, !11}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/select.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/select.ll
@@ -24,7 +24,7 @@ attributes #0 = { noinline norecurse nounwind ssp uwtable "correctly-rounded-div
 !llvm.module.flags = !{!7, !8, !9, !10}
 !llvm.ident = !{!11}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "select.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{!4}
@@ -35,7 +35,7 @@ attributes #0 = { noinline norecurse nounwind ssp uwtable "correctly-rounded-div
 !8 = !{i32 2, !"Debug Info Version", i32 3}
 !9 = !{i32 1, !"wchar_size", i32 4}
 !10 = !{i32 7, !"PIC Level", i32 2}
-!11 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!11 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !12 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 10, type: !13, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !13 = !DISubroutineType(types: !14)
 !14 = !{!6}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/shufflevector.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/shufflevector.ll
@@ -39,7 +39,7 @@ attributes #3 = { nounwind }
 !llvm.module.flags = !{!11, !12, !13, !14}
 !llvm.ident = !{!15}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, retainedTypes: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, retainedTypes: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "shufflevector.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{!4, !10}
@@ -54,7 +54,7 @@ attributes #3 = { nounwind }
 !12 = !{i32 2, !"Debug Info Version", i32 3}
 !13 = !{i32 1, !"wchar_size", i32 4}
 !14 = !{i32 7, !"PIC Level", i32 2}
-!15 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!15 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !16 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 5, type: !17, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !17 = !DISubroutineType(types: !18)
 !18 = !{!19, !19, !20}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/struct-parameters.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/struct-parameters.ll
@@ -24,14 +24,14 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "struct-parameters.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 17, type: !9, scopeLine: 17, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/thread-local.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/thread-local.ll
@@ -48,7 +48,7 @@ attributes #1 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "x", linkageName: "_ZL1x", scope: !2, file: !3, line: 1, type: !6, isLocal: true, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "thread-local.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -57,7 +57,7 @@ attributes #1 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !8 = !{i32 2, !"Debug Info Version", i32 3}
 !9 = !{i32 1, !"wchar_size", i32 4}
 !10 = !{i32 7, !"PIC Level", i32 2}
-!11 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!11 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !12 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 3, type: !13, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !13 = !DISubroutineType(types: !14)
 !14 = !{!6}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/try-catch.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/try-catch.ll
@@ -364,7 +364,7 @@ attributes #4 = { nounwind }
 !llvm.module.flags = !{!7, !8, !9, !10}
 !llvm.ident = !{!11}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "try-catch.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{!4}
@@ -375,7 +375,7 @@ attributes #4 = { nounwind }
 !8 = !{i32 2, !"Debug Info Version", i32 3}
 !9 = !{i32 1, !"wchar_size", i32 4}
 !10 = !{i32 7, !"PIC Level", i32 2}
-!11 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!11 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !12 = distinct !DISubprogram(name: "h", linkageName: "_Z1hi", scope: !1, file: !1, line: 21, type: !13, scopeLine: 21, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !13 = !DISubroutineType(types: !14)
 !14 = !{null, !6}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/undef.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/undef.ll
@@ -37,14 +37,14 @@ attributes #2 = { cold noreturn nounwind }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "undef.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !9, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11, !12}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/union.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/union.ll
@@ -24,14 +24,14 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "union.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 6, type: !9, scopeLine: 6, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/var-args.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/var-args.ll
@@ -243,7 +243,7 @@ attributes #7 = { nounwind allocsize(0) }
 !llvm.module.flags = !{!6, !7, !8, !9}
 !llvm.ident = !{!10}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, retainedTypes: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, retainedTypes: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "var-args.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{!4}
@@ -253,7 +253,7 @@ attributes #7 = { nounwind allocsize(0) }
 !7 = !{i32 2, !"Debug Info Version", i32 3}
 !8 = !{i32 1, !"wchar_size", i32 4}
 !9 = !{i32 7, !"PIC Level", i32 2}
-!10 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!10 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !11 = distinct !DISubprogram(name: "PrintInts", scope: !1, file: !1, line: 8, type: !12, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !12 = !DISubroutineType(types: !13)
 !13 = !{null, !14, null}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/vector-1.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/vector-1.ll
@@ -24,7 +24,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !llvm.module.flags = !{!15, !16, !17, !18}
 !llvm.ident = !{!19}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "vector-1.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{!4, !11, !13}
@@ -43,7 +43,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !16 = !{i32 2, !"Debug Info Version", i32 3}
 !17 = !{i32 1, !"wchar_size", i32 4}
 !18 = !{i32 7, !"PIC Level", i32 2}
-!19 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!19 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !20 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 5, type: !21, scopeLine: 5, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !21 = !DISubroutineType(types: !22)
 !22 = !{!23}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/vector-2.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/vector-2.ll
@@ -24,7 +24,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !llvm.module.flags = !{!15, !16, !17, !18}
 !llvm.ident = !{!19}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "vector-2.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{!4, !11, !13}
@@ -43,7 +43,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !16 = !{i32 2, !"Debug Info Version", i32 3}
 !17 = !{i32 1, !"wchar_size", i32 4}
 !18 = !{i32 7, !"PIC Level", i32 2}
-!19 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!19 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !20 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 5, type: !21, scopeLine: 5, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !21 = !DISubroutineType(types: !22)
 !22 = !{!23}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/vector-3.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/vector-3.ll
@@ -24,7 +24,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !llvm.module.flags = !{!15, !16, !17, !18}
 !llvm.ident = !{!19}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "vector-3.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{!4, !11, !13}
@@ -43,7 +43,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !16 = !{i32 2, !"Debug Info Version", i32 3}
 !17 = !{i32 1, !"wchar_size", i32 4}
 !18 = !{i32 7, !"PIC Level", i32 2}
-!19 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!19 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !20 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 5, type: !21, scopeLine: 5, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !21 = !DISubroutineType(types: !22)
 !22 = !{!8}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/vector-4.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/vector-4.ll
@@ -12,11 +12,11 @@ target triple = "x86_64-apple-macosx10.14.0"
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "vector-4.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/virtual-inheritance.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/virtual-inheritance.ll
@@ -469,14 +469,14 @@ attributes #3 = { nounwind }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "virtual-inheritance.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 33, type: !9, scopeLine: 33, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/aggressive_optimization/vla.ll
+++ b/frontend/llvm/test/regression/import/aggressive_optimization/vla.ll
@@ -69,14 +69,14 @@ attributes #3 = { nounwind }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "vla.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/aggressive_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 2, type: !9, scopeLine: 2, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{null, !11}

--- a/frontend/llvm/test/regression/import/basic_optimization/aggregate-in-reg-1.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/aggregate-in-reg-1.ll
@@ -170,14 +170,14 @@ attributes #4 = { argmemonly nounwind }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "aggregate-in-reg-1.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 19, type: !9, scopeLine: 19, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11, !12}

--- a/frontend/llvm/test/regression/import/basic_optimization/aggregate-in-reg-2.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/aggregate-in-reg-2.ll
@@ -110,14 +110,14 @@ attributes #3 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "aggregate-in-reg-2.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "f", linkageName: "_Z1ff", scope: !1, file: !1, line: 12, type: !9, scopeLine: 12, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !19}

--- a/frontend/llvm/test/regression/import/basic_optimization/array-init.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/array-init.ll
@@ -23,7 +23,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "k", scope: !2, file: !3, line: 3, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "array-init.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -41,4 +41,4 @@ target triple = "x86_64-apple-macosx10.14.0"
 !17 = !{i32 2, !"Debug Info Version", i32 3}
 !18 = !{i32 1, !"wchar_size", i32 4}
 !19 = !{i32 7, !"PIC Level", i32 2}
-!20 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!20 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}

--- a/frontend/llvm/test/regression/import/basic_optimization/asm.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/asm.ll
@@ -49,14 +49,14 @@ attributes #3 = { nounwind readnone }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "asm.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !9, scopeLine: 3, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/basic_optimization/atomic.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/atomic.ll
@@ -38,7 +38,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "x", scope: !2, file: !3, line: 1, type: !8, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, retainedTypes: !5, globals: !7, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, retainedTypes: !5, globals: !7, nameTableKind: GNU)
 !3 = !DIFile(filename: "atomic.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !4 = !{}
 !5 = !{!6}
@@ -51,7 +51,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !12 = !{i32 2, !"Debug Info Version", i32 3}
 !13 = !{i32 1, !"wchar_size", i32 4}
 !14 = !{i32 7, !"PIC Level", i32 2}
-!15 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!15 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !16 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 3, type: !17, scopeLine: 3, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !17 = !DISubroutineType(types: !5)
 !18 = !DILocation(line: 4, column: 5, scope: !16)

--- a/frontend/llvm/test/regression/import/basic_optimization/basic-loop.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/basic-loop.ll
@@ -86,7 +86,7 @@ attributes #1 = { nounwind readnone speculatable }
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "a", scope: !2, file: !3, line: 1, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "basic-loop.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -98,7 +98,7 @@ attributes #1 = { nounwind readnone speculatable }
 !11 = !{i32 2, !"Debug Info Version", i32 3}
 !12 = !{i32 1, !"wchar_size", i32 4}
 !13 = !{i32 7, !"PIC Level", i32 2}
-!14 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!14 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !15 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 3, type: !16, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !16 = !DISubroutineType(types: !17)
 !17 = !{!18, !18, !19}

--- a/frontend/llvm/test/regression/import/basic_optimization/bit-field-1.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/bit-field-1.ll
@@ -51,14 +51,14 @@ attributes #2 = { argmemonly nounwind }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "bit-field-1.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 8, type: !9, scopeLine: 8, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/basic_optimization/bit-field-2.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/bit-field-2.ll
@@ -23,7 +23,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "b", scope: !2, file: !3, line: 4, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "bit-field-2.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -39,4 +39,4 @@ target triple = "x86_64-apple-macosx10.14.0"
 !15 = !{i32 2, !"Debug Info Version", i32 3}
 !16 = !{i32 1, !"wchar_size", i32 4}
 !17 = !{i32 7, !"PIC Level", i32 2}
-!18 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!18 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}

--- a/frontend/llvm/test/regression/import/basic_optimization/bitwise-cond-1.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/bitwise-cond-1.ll
@@ -93,14 +93,14 @@ attributes #1 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "bitwise-cond-1.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 1, type: !9, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11, !11, !11}

--- a/frontend/llvm/test/regression/import/basic_optimization/bitwise-cond-2.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/bitwise-cond-2.ll
@@ -86,7 +86,7 @@ attributes #1 = { nounwind readnone speculatable }
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "g", scope: !2, file: !3, line: 1, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "bitwise-cond-2.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -95,7 +95,7 @@ attributes #1 = { nounwind readnone speculatable }
 !8 = !{i32 2, !"Debug Info Version", i32 3}
 !9 = !{i32 1, !"wchar_size", i32 4}
 !10 = !{i32 7, !"PIC Level", i32 2}
-!11 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!11 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !12 = distinct !DISubprogram(name: "foo", scope: !3, file: !3, line: 3, type: !13, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !13 = !DISubroutineType(types: !14)
 !14 = !{!6, !6, !6}

--- a/frontend/llvm/test/regression/import/basic_optimization/bitwise-op.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/bitwise-op.ll
@@ -31,14 +31,14 @@ attributes #1 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "bitwise-op.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 1, type: !9, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/basic_optimization/bool-op-select.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/bool-op-select.ll
@@ -56,7 +56,7 @@ attributes #0 = { noinline norecurse nounwind ssp uwtable "correctly-rounded-div
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "a", scope: !2, file: !3, line: 8, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "bool-op-select.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -65,7 +65,7 @@ attributes #0 = { noinline norecurse nounwind ssp uwtable "correctly-rounded-div
 !8 = !{i32 2, !"Debug Info Version", i32 3}
 !9 = !{i32 1, !"wchar_size", i32 4}
 !10 = !{i32 7, !"PIC Level", i32 2}
-!11 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!11 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !12 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 10, type: !13, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !13 = !DISubroutineType(types: !14)
 !14 = !{!6}

--- a/frontend/llvm/test/regression/import/basic_optimization/bool.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/bool.ll
@@ -56,7 +56,7 @@ attributes #3 = { nounwind readnone speculatable }
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "b", scope: !2, file: !3, line: 1, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "bool.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -65,7 +65,7 @@ attributes #3 = { nounwind readnone speculatable }
 !8 = !{i32 2, !"Debug Info Version", i32 3}
 !9 = !{i32 1, !"wchar_size", i32 4}
 !10 = !{i32 7, !"PIC Level", i32 2}
-!11 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!11 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !12 = distinct !DISubprogram(name: "f", linkageName: "_Z1fb", scope: !3, file: !3, line: 3, type: !13, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !13 = !DISubroutineType(types: !14)
 !14 = !{!15, !6}

--- a/frontend/llvm/test/regression/import/basic_optimization/branch-undef.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/branch-undef.ll
@@ -48,14 +48,14 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "branch-undef.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 1, type: !9, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/basic_optimization/call-args.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/call-args.ll
@@ -45,14 +45,14 @@ attributes #1 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "call-args.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 1, type: !9, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11}

--- a/frontend/llvm/test/regression/import/basic_optimization/complex.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/complex.ll
@@ -45,14 +45,14 @@ attributes #1 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "complex.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !9, scopeLine: 3, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/basic_optimization/constructors.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/constructors.ll
@@ -175,14 +175,14 @@ attributes #7 = { nounwind }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "constructors.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "f", linkageName: "_Z1fP6Vector", scope: !1, file: !1, line: 14, type: !9, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !12}

--- a/frontend/llvm/test/regression/import/basic_optimization/empty-array-1.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/empty-array-1.ll
@@ -24,7 +24,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "d", scope: !2, file: !3, line: 5, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "empty-array-1.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -44,4 +44,4 @@ target triple = "x86_64-apple-macosx10.14.0"
 !19 = !{i32 2, !"Debug Info Version", i32 3}
 !20 = !{i32 1, !"wchar_size", i32 4}
 !21 = !{i32 7, !"PIC Level", i32 2}
-!22 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!22 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}

--- a/frontend/llvm/test/regression/import/basic_optimization/empty-array-2.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/empty-array-2.ll
@@ -24,7 +24,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "c", scope: !2, file: !3, line: 6, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "empty-array-2.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -43,4 +43,4 @@ target triple = "x86_64-apple-macosx10.14.0"
 !18 = !{i32 2, !"Debug Info Version", i32 3}
 !19 = !{i32 1, !"wchar_size", i32 4}
 !20 = !{i32 7, !"PIC Level", i32 2}
-!21 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!21 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}

--- a/frontend/llvm/test/regression/import/basic_optimization/empty-array-3.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/empty-array-3.ll
@@ -21,7 +21,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "c", scope: !2, file: !3, line: 4, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "empty-array-3.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -38,4 +38,4 @@ target triple = "x86_64-apple-macosx10.14.0"
 !16 = !{i32 2, !"Debug Info Version", i32 3}
 !17 = !{i32 1, !"wchar_size", i32 4}
 !18 = !{i32 7, !"PIC Level", i32 2}
-!19 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!19 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}

--- a/frontend/llvm/test/regression/import/basic_optimization/empty-function-body.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/empty-function-body.ll
@@ -24,14 +24,14 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "empty-function-body.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "GEN2_w_test2_terminate", scope: !1, file: !1, line: 1, type: !9, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{null}

--- a/frontend/llvm/test/regression/import/basic_optimization/file-intrinsics.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/file-intrinsics.ll
@@ -131,14 +131,14 @@ attributes #2 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "file-intrinsics.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !9, scopeLine: 3, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/basic_optimization/flexible-array-member.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/flexible-array-member.ll
@@ -35,7 +35,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "l", scope: !2, file: !3, line: 6, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "flexible-array-member.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -52,7 +52,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !16 = !{i32 2, !"Debug Info Version", i32 3}
 !17 = !{i32 1, !"wchar_size", i32 4}
 !18 = !{i32 7, !"PIC Level", i32 2}
-!19 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!19 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !20 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 8, type: !21, scopeLine: 8, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !21 = !DISubroutineType(types: !22)
 !22 = !{!9}

--- a/frontend/llvm/test/regression/import/basic_optimization/gv-init.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/gv-init.ll
@@ -189,7 +189,7 @@ attributes #1 = { nounwind readnone speculatable }
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "b", scope: !2, file: !3, line: 2, type: !16, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "gv-init.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !4 = !{}
 !5 = !{!0, !6, !9, !14}
@@ -210,7 +210,7 @@ attributes #1 = { nounwind readnone speculatable }
 !20 = !{i32 2, !"Debug Info Version", i32 3}
 !21 = !{i32 1, !"wchar_size", i32 4}
 !22 = !{i32 7, !"PIC Level", i32 2}
-!23 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!23 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !24 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 7, type: !25, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !25 = !DISubroutineType(types: !26)
 !26 = !{!8, !8, !27}

--- a/frontend/llvm/test/regression/import/basic_optimization/linked-list.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/linked-list.ll
@@ -41,7 +41,7 @@ attributes #1 = { nounwind readnone speculatable }
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "head", scope: !2, file: !3, line: 6, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "linked-list.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -55,7 +55,7 @@ attributes #1 = { nounwind readnone speculatable }
 !13 = !{i32 2, !"Debug Info Version", i32 3}
 !14 = !{i32 1, !"wchar_size", i32 4}
 !15 = !{i32 7, !"PIC Level", i32 2}
-!16 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!16 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !17 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 8, type: !18, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !18 = !DISubroutineType(types: !19)
 !19 = !{!9, !9, !20}

--- a/frontend/llvm/test/regression/import/basic_optimization/local-array-1.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/local-array-1.ll
@@ -94,14 +94,14 @@ attributes #2 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "local-array-1.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 6, type: !9, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11, !12}

--- a/frontend/llvm/test/regression/import/basic_optimization/local-array-2.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/local-array-2.ll
@@ -137,14 +137,14 @@ attributes #3 = { argmemonly nounwind }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "local-array-2.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 4, type: !9, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11, !13}

--- a/frontend/llvm/test/regression/import/basic_optimization/mem-intrinsics.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/mem-intrinsics.ll
@@ -71,7 +71,7 @@ attributes #2 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!6, !7, !8, !9}
 !llvm.ident = !{!10}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, retainedTypes: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, retainedTypes: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "mem-intrinsics.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{!4}
@@ -81,7 +81,7 @@ attributes #2 = { nounwind readnone speculatable }
 !7 = !{i32 2, !"Debug Info Version", i32 3}
 !8 = !{i32 1, !"wchar_size", i32 4}
 !9 = !{i32 7, !"PIC Level", i32 2}
-!10 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!10 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !11 = distinct !DISubprogram(name: "cst", scope: !1, file: !1, line: 3, type: !12, scopeLine: 3, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !12 = !DISubroutineType(types: !13)
 !13 = !{!5}

--- a/frontend/llvm/test/regression/import/basic_optimization/multiple-inheritance.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/multiple-inheritance.ll
@@ -37,7 +37,7 @@ attributes #0 = { noinline norecurse nounwind ssp uwtable "correctly-rounded-div
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "c", scope: !2, file: !3, line: 21, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "multiple-inheritance.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -69,7 +69,7 @@ attributes #0 = { noinline norecurse nounwind ssp uwtable "correctly-rounded-div
 !31 = !{i32 2, !"Debug Info Version", i32 3}
 !32 = !{i32 1, !"wchar_size", i32 4}
 !33 = !{i32 7, !"PIC Level", i32 2}
-!34 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!34 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !35 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 23, type: !36, scopeLine: 23, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !36 = !DISubroutineType(types: !37)
 !37 = !{!12}

--- a/frontend/llvm/test/regression/import/basic_optimization/nested-struct.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/nested-struct.ll
@@ -35,14 +35,14 @@ attributes #2 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "nested-struct.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 7, type: !9, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11, !12}

--- a/frontend/llvm/test/regression/import/basic_optimization/noexcept.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/noexcept.ll
@@ -76,14 +76,14 @@ attributes #4 = { nounwind }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "noexcept.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "g", linkageName: "_Z1gv", scope: !1, file: !1, line: 3, type: !9, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/basic_optimization/non-term-1.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/non-term-1.ll
@@ -63,14 +63,14 @@ attributes #3 = { noreturn }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "non-term-1.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !9, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11, !12}

--- a/frontend/llvm/test/regression/import/basic_optimization/non-term-2.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/non-term-2.ll
@@ -43,14 +43,14 @@ attributes #1 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "non-term-2.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !9, scopeLine: 3, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/basic_optimization/nullptr.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/nullptr.ll
@@ -42,14 +42,14 @@ attributes #2 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "nullptr.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "f", linkageName: "_Z1fDn", scope: !1, file: !1, line: 1, type: !9, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !12}

--- a/frontend/llvm/test/regression/import/basic_optimization/opaque-struct.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/opaque-struct.ll
@@ -36,7 +36,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "s", scope: !2, file: !3, line: 10, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "opaque-struct.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -53,7 +53,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !16 = !{i32 2, !"Debug Info Version", i32 3}
 !17 = !{i32 1, !"wchar_size", i32 4}
 !18 = !{i32 7, !"PIC Level", i32 2}
-!19 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!19 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !20 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 12, type: !21, scopeLine: 12, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !21 = !DISubroutineType(types: !22)
 !22 = !{!11}

--- a/frontend/llvm/test/regression/import/basic_optimization/phi-1.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/phi-1.ll
@@ -86,7 +86,7 @@ attributes #1 = { nounwind readnone speculatable }
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "a", scope: !2, file: !3, line: 1, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "phi-1.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -98,7 +98,7 @@ attributes #1 = { nounwind readnone speculatable }
 !11 = !{i32 2, !"Debug Info Version", i32 3}
 !12 = !{i32 1, !"wchar_size", i32 4}
 !13 = !{i32 7, !"PIC Level", i32 2}
-!14 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!14 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !15 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 3, type: !16, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !16 = !DISubroutineType(types: !17)
 !17 = !{!18, !18, !19}

--- a/frontend/llvm/test/regression/import/basic_optimization/phi-2.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/phi-2.ll
@@ -226,14 +226,14 @@ attributes #2 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "phi-2.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 18, type: !9, scopeLine: 18, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11, !12}

--- a/frontend/llvm/test/regression/import/basic_optimization/phi-3.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/phi-3.ll
@@ -220,14 +220,14 @@ attributes #2 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "phi-3.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !12, !12, !12}

--- a/frontend/llvm/test/regression/import/basic_optimization/phi-4.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/phi-4.ll
@@ -114,14 +114,14 @@ attributes #1 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "phi-4.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 1, type: !9, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11, !12}

--- a/frontend/llvm/test/regression/import/basic_optimization/pod-types.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/pod-types.ll
@@ -124,7 +124,7 @@ attributes #2 = { argmemonly nounwind }
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "i", scope: !2, file: !3, line: 1, type: !29, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "pod-types.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !4 = !{}
 !5 = !{!0, !6, !9, !12, !15, !19, !22}
@@ -156,7 +156,7 @@ attributes #2 = { argmemonly nounwind }
 !31 = !{i32 2, !"Debug Info Version", i32 3}
 !32 = !{i32 1, !"wchar_size", i32 4}
 !33 = !{i32 7, !"PIC Level", i32 2}
-!34 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!34 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !35 = distinct !DISubprogram(name: "fun", scope: !3, file: !3, line: 15, type: !36, scopeLine: 15, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !36 = !DISubroutineType(types: !37)
 !37 = !{null}

--- a/frontend/llvm/test/regression/import/basic_optimization/pointer-arithmetic.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/pointer-arithmetic.ll
@@ -107,7 +107,7 @@ attributes #2 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ptr_fun", scope: !2, file: !3, line: 7, type: !26, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "pointer-arithmetic.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !4 = !{}
 !5 = !{!0, !6, !14, !23}
@@ -137,7 +137,7 @@ attributes #2 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-
 !29 = !{i32 2, !"Debug Info Version", i32 3}
 !30 = !{i32 1, !"wchar_size", i32 4}
 !31 = !{i32 7, !"PIC Level", i32 2}
-!32 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!32 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !33 = distinct !DISubprogram(name: "f", linkageName: "_Z1fv", scope: !3, file: !3, line: 3, type: !34, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !34 = !DISubroutineType(types: !35)
 !35 = !{!20}

--- a/frontend/llvm/test/regression/import/basic_optimization/ptr-to-int.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/ptr-to-int.ll
@@ -34,7 +34,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "x", scope: !2, file: !3, line: 7, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "ptr-to-int.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -45,7 +45,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !10 = !{i32 2, !"Debug Info Version", i32 3}
 !11 = !{i32 1, !"wchar_size", i32 4}
 !12 = !{i32 7, !"PIC Level", i32 2}
-!13 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!13 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !14 = distinct !DISubprogram(name: "f", scope: !3, file: !3, line: 3, type: !15, scopeLine: 3, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !15 = !DISubroutineType(types: !16)
 !16 = !{!17}

--- a/frontend/llvm/test/regression/import/basic_optimization/reference.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/reference.ll
@@ -54,14 +54,14 @@ attributes #2 = { noinline norecurse nounwind ssp uwtable "correctly-rounded-div
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "reference.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "f", linkageName: "_Z1fRi", scope: !1, file: !1, line: 1, type: !9, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{null, !11}

--- a/frontend/llvm/test/regression/import/basic_optimization/select.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/select.ll
@@ -56,7 +56,7 @@ attributes #0 = { noinline norecurse nounwind ssp uwtable "correctly-rounded-div
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "a", scope: !2, file: !3, line: 8, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "select.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -65,7 +65,7 @@ attributes #0 = { noinline norecurse nounwind ssp uwtable "correctly-rounded-div
 !8 = !{i32 2, !"Debug Info Version", i32 3}
 !9 = !{i32 1, !"wchar_size", i32 4}
 !10 = !{i32 7, !"PIC Level", i32 2}
-!11 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!11 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !12 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 10, type: !13, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !13 = !DISubroutineType(types: !14)
 !14 = !{!6}

--- a/frontend/llvm/test/regression/import/basic_optimization/shufflevector.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/shufflevector.ll
@@ -48,7 +48,7 @@ attributes #2 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!11, !12, !13, !14}
 !llvm.ident = !{!15}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, retainedTypes: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, retainedTypes: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "shufflevector.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{!4, !10}
@@ -63,7 +63,7 @@ attributes #2 = { nounwind readnone speculatable }
 !12 = !{i32 2, !"Debug Info Version", i32 3}
 !13 = !{i32 1, !"wchar_size", i32 4}
 !14 = !{i32 7, !"PIC Level", i32 2}
-!15 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!15 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !16 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 5, type: !17, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !17 = !DISubroutineType(types: !18)
 !18 = !{!19, !19, !20}

--- a/frontend/llvm/test/regression/import/basic_optimization/struct-parameters.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/struct-parameters.ll
@@ -72,14 +72,14 @@ attributes #2 = { argmemonly nounwind }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "struct-parameters.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "f", scope: !1, file: !1, line: 9, type: !9, scopeLine: 9, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !21}

--- a/frontend/llvm/test/regression/import/basic_optimization/thread-local.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/thread-local.ll
@@ -48,7 +48,7 @@ attributes #1 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "x", linkageName: "_ZL1x", scope: !2, file: !3, line: 1, type: !6, isLocal: true, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "thread-local.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -57,7 +57,7 @@ attributes #1 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !8 = !{i32 2, !"Debug Info Version", i32 3}
 !9 = !{i32 1, !"wchar_size", i32 4}
 !10 = !{i32 7, !"PIC Level", i32 2}
-!11 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!11 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !12 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 3, type: !13, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !13 = !DISubroutineType(types: !14)
 !14 = !{!6}

--- a/frontend/llvm/test/regression/import/basic_optimization/try-catch.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/try-catch.ll
@@ -458,7 +458,7 @@ attributes #5 = { nounwind }
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "G", scope: !2, file: !3, line: 1, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "try-catch.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -467,7 +467,7 @@ attributes #5 = { nounwind }
 !8 = !{i32 2, !"Debug Info Version", i32 3}
 !9 = !{i32 1, !"wchar_size", i32 4}
 !10 = !{i32 7, !"PIC Level", i32 2}
-!11 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!11 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !12 = distinct !DISubprogram(name: "h", linkageName: "_Z1hi", scope: !3, file: !3, line: 21, type: !13, scopeLine: 21, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !13 = !DISubroutineType(types: !14)
 !14 = !{null, !6}

--- a/frontend/llvm/test/regression/import/basic_optimization/undef.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/undef.ll
@@ -39,14 +39,14 @@ attributes #1 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "undef.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !9, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11, !12}

--- a/frontend/llvm/test/regression/import/basic_optimization/union.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/union.ll
@@ -51,14 +51,14 @@ attributes #2 = { argmemonly nounwind }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "union.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 6, type: !9, scopeLine: 6, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/basic_optimization/var-args.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/var-args.ll
@@ -263,7 +263,7 @@ attributes #5 = { allocsize(0) }
 !llvm.module.flags = !{!6, !7, !8, !9}
 !llvm.ident = !{!10}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, retainedTypes: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, retainedTypes: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "var-args.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{!4}
@@ -273,7 +273,7 @@ attributes #5 = { allocsize(0) }
 !7 = !{i32 2, !"Debug Info Version", i32 3}
 !8 = !{i32 1, !"wchar_size", i32 4}
 !9 = !{i32 7, !"PIC Level", i32 2}
-!10 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!10 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !11 = distinct !DISubprogram(name: "PrintInts", scope: !1, file: !1, line: 8, type: !12, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !12 = !DISubroutineType(types: !13)
 !13 = !{null, !14, null}

--- a/frontend/llvm/test/regression/import/basic_optimization/vector-1.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/vector-1.ll
@@ -55,7 +55,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "a", scope: !2, file: !3, line: 3, type: !8, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "vector-1.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !4 = !{}
 !5 = !{!0, !6, !13}
@@ -72,7 +72,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !16 = !{i32 2, !"Debug Info Version", i32 3}
 !17 = !{i32 1, !"wchar_size", i32 4}
 !18 = !{i32 7, !"PIC Level", i32 2}
-!19 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!19 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !20 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 5, type: !21, scopeLine: 5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !21 = !DISubroutineType(types: !22)
 !22 = !{!23}

--- a/frontend/llvm/test/regression/import/basic_optimization/vector-2.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/vector-2.ll
@@ -55,7 +55,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "a", scope: !2, file: !3, line: 3, type: !8, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "vector-2.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !4 = !{}
 !5 = !{!0, !6, !13}
@@ -72,7 +72,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !16 = !{i32 2, !"Debug Info Version", i32 3}
 !17 = !{i32 1, !"wchar_size", i32 4}
 !18 = !{i32 7, !"PIC Level", i32 2}
-!19 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!19 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !20 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 5, type: !21, scopeLine: 5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !21 = !DISubroutineType(types: !22)
 !22 = !{!23}

--- a/frontend/llvm/test/regression/import/basic_optimization/vector-3.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/vector-3.ll
@@ -58,7 +58,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "a", scope: !2, file: !3, line: 3, type: !8, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "vector-3.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !4 = !{}
 !5 = !{!0, !6, !13}
@@ -75,7 +75,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !16 = !{i32 2, !"Debug Info Version", i32 3}
 !17 = !{i32 1, !"wchar_size", i32 4}
 !18 = !{i32 7, !"PIC Level", i32 2}
-!19 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!19 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !20 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 5, type: !21, scopeLine: 5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !21 = !DISubroutineType(types: !22)
 !22 = !{!10}

--- a/frontend/llvm/test/regression/import/basic_optimization/vector-4.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/vector-4.ll
@@ -35,14 +35,14 @@ attributes #1 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "vector-4.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "f", scope: !1, file: !1, line: 3, type: !9, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11}

--- a/frontend/llvm/test/regression/import/basic_optimization/virtual-inheritance.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/virtual-inheritance.ll
@@ -478,14 +478,14 @@ attributes #3 = { nounwind }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "virtual-inheritance.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 33, type: !9, scopeLine: 33, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/basic_optimization/vla.ll
+++ b/frontend/llvm/test/regression/import/basic_optimization/vla.ll
@@ -131,14 +131,14 @@ attributes #3 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "vla.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/basic_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 2, type: !9, scopeLine: 2, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{null, !11}

--- a/frontend/llvm/test/regression/import/no_optimization/aggregate-in-reg-1.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/aggregate-in-reg-1.ll
@@ -284,14 +284,14 @@ attributes #4 = { argmemonly nounwind }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "aggregate-in-reg-1.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 19, type: !9, scopeLine: 19, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11, !12}

--- a/frontend/llvm/test/regression/import/no_optimization/aggregate-in-reg-2.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/aggregate-in-reg-2.ll
@@ -120,14 +120,14 @@ attributes #3 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "aggregate-in-reg-2.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "f", linkageName: "_Z1ff", scope: !1, file: !1, line: 12, type: !9, scopeLine: 12, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !19}

--- a/frontend/llvm/test/regression/import/no_optimization/array-init.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/array-init.ll
@@ -23,7 +23,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "k", scope: !2, file: !3, line: 3, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "array-init.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -41,4 +41,4 @@ target triple = "x86_64-apple-macosx10.14.0"
 !17 = !{i32 2, !"Debug Info Version", i32 3}
 !18 = !{i32 1, !"wchar_size", i32 4}
 !19 = !{i32 7, !"PIC Level", i32 2}
-!20 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!20 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}

--- a/frontend/llvm/test/regression/import/no_optimization/asm.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/asm.ll
@@ -67,14 +67,14 @@ attributes #3 = { nounwind readnone }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "asm.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !9, scopeLine: 3, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/no_optimization/atomic.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/atomic.ll
@@ -42,7 +42,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "x", scope: !2, file: !3, line: 1, type: !8, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, retainedTypes: !5, globals: !7, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, retainedTypes: !5, globals: !7, nameTableKind: GNU)
 !3 = !DIFile(filename: "atomic.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !4 = !{}
 !5 = !{!6}
@@ -55,7 +55,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !12 = !{i32 2, !"Debug Info Version", i32 3}
 !13 = !{i32 1, !"wchar_size", i32 4}
 !14 = !{i32 7, !"PIC Level", i32 2}
-!15 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!15 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !16 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 3, type: !17, scopeLine: 3, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !17 = !DISubroutineType(types: !5)
 !18 = !DILocation(line: 4, column: 5, scope: !16)

--- a/frontend/llvm/test/regression/import/no_optimization/basic-loop.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/basic-loop.ll
@@ -113,7 +113,7 @@ attributes #1 = { nounwind readnone speculatable }
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "a", scope: !2, file: !3, line: 1, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "basic-loop.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -125,7 +125,7 @@ attributes #1 = { nounwind readnone speculatable }
 !11 = !{i32 2, !"Debug Info Version", i32 3}
 !12 = !{i32 1, !"wchar_size", i32 4}
 !13 = !{i32 7, !"PIC Level", i32 2}
-!14 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!14 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !15 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 3, type: !16, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !16 = !DISubroutineType(types: !17)
 !17 = !{!18, !18, !19}

--- a/frontend/llvm/test/regression/import/no_optimization/bit-field-1.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/bit-field-1.ll
@@ -55,14 +55,14 @@ attributes #2 = { argmemonly nounwind }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "bit-field-1.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 8, type: !9, scopeLine: 8, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/no_optimization/bit-field-2.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/bit-field-2.ll
@@ -23,7 +23,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "b", scope: !2, file: !3, line: 4, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "bit-field-2.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -39,4 +39,4 @@ target triple = "x86_64-apple-macosx10.14.0"
 !15 = !{i32 2, !"Debug Info Version", i32 3}
 !16 = !{i32 1, !"wchar_size", i32 4}
 !17 = !{i32 7, !"PIC Level", i32 2}
-!18 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!18 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}

--- a/frontend/llvm/test/regression/import/no_optimization/bitwise-cond-1.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/bitwise-cond-1.ll
@@ -137,14 +137,14 @@ attributes #1 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "bitwise-cond-1.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 1, type: !9, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11, !11, !11}

--- a/frontend/llvm/test/regression/import/no_optimization/bitwise-cond-2.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/bitwise-cond-2.ll
@@ -115,7 +115,7 @@ attributes #1 = { nounwind readnone speculatable }
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "g", scope: !2, file: !3, line: 1, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "bitwise-cond-2.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -124,7 +124,7 @@ attributes #1 = { nounwind readnone speculatable }
 !8 = !{i32 2, !"Debug Info Version", i32 3}
 !9 = !{i32 1, !"wchar_size", i32 4}
 !10 = !{i32 7, !"PIC Level", i32 2}
-!11 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!11 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !12 = distinct !DISubprogram(name: "foo", scope: !3, file: !3, line: 3, type: !13, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !13 = !DISubroutineType(types: !14)
 !14 = !{!6, !6, !6}

--- a/frontend/llvm/test/regression/import/no_optimization/bitwise-op.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/bitwise-op.ll
@@ -52,14 +52,14 @@ attributes #1 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "bitwise-op.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 1, type: !9, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/no_optimization/bool-op-select.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/bool-op-select.ll
@@ -72,7 +72,7 @@ attributes #0 = { noinline norecurse nounwind ssp uwtable "correctly-rounded-div
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "a", scope: !2, file: !3, line: 8, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "bool-op-select.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -81,7 +81,7 @@ attributes #0 = { noinline norecurse nounwind ssp uwtable "correctly-rounded-div
 !8 = !{i32 2, !"Debug Info Version", i32 3}
 !9 = !{i32 1, !"wchar_size", i32 4}
 !10 = !{i32 7, !"PIC Level", i32 2}
-!11 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!11 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !12 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 10, type: !13, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !13 = !DISubroutineType(types: !14)
 !14 = !{!6}

--- a/frontend/llvm/test/regression/import/no_optimization/bool.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/bool.ll
@@ -66,7 +66,7 @@ attributes #3 = { noinline norecurse nounwind ssp uwtable "correctly-rounded-div
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "b", scope: !2, file: !3, line: 1, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "bool.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -75,7 +75,7 @@ attributes #3 = { noinline norecurse nounwind ssp uwtable "correctly-rounded-div
 !8 = !{i32 2, !"Debug Info Version", i32 3}
 !9 = !{i32 1, !"wchar_size", i32 4}
 !10 = !{i32 7, !"PIC Level", i32 2}
-!11 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!11 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !12 = distinct !DISubprogram(name: "f", linkageName: "_Z1fb", scope: !3, file: !3, line: 3, type: !13, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !13 = !DISubroutineType(types: !14)
 !14 = !{!15, !6}

--- a/frontend/llvm/test/regression/import/no_optimization/branch-undef.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/branch-undef.ll
@@ -59,14 +59,14 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "branch-undef.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 1, type: !9, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/no_optimization/call-args.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/call-args.ll
@@ -65,14 +65,14 @@ attributes #1 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "call-args.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 1, type: !9, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11}

--- a/frontend/llvm/test/regression/import/no_optimization/complex.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/complex.ll
@@ -53,14 +53,14 @@ attributes #1 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "complex.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !9, scopeLine: 3, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/no_optimization/constructors.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/constructors.ll
@@ -245,14 +245,14 @@ attributes #7 = { nounwind }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "constructors.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "f", linkageName: "_Z1fP6Vector", scope: !1, file: !1, line: 14, type: !9, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !12}

--- a/frontend/llvm/test/regression/import/no_optimization/empty-array-1.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/empty-array-1.ll
@@ -24,7 +24,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "d", scope: !2, file: !3, line: 5, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "empty-array-1.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -44,4 +44,4 @@ target triple = "x86_64-apple-macosx10.14.0"
 !19 = !{i32 2, !"Debug Info Version", i32 3}
 !20 = !{i32 1, !"wchar_size", i32 4}
 !21 = !{i32 7, !"PIC Level", i32 2}
-!22 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!22 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}

--- a/frontend/llvm/test/regression/import/no_optimization/empty-array-2.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/empty-array-2.ll
@@ -24,7 +24,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "c", scope: !2, file: !3, line: 6, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "empty-array-2.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -43,4 +43,4 @@ target triple = "x86_64-apple-macosx10.14.0"
 !18 = !{i32 2, !"Debug Info Version", i32 3}
 !19 = !{i32 1, !"wchar_size", i32 4}
 !20 = !{i32 7, !"PIC Level", i32 2}
-!21 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!21 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}

--- a/frontend/llvm/test/regression/import/no_optimization/empty-array-3.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/empty-array-3.ll
@@ -21,7 +21,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "c", scope: !2, file: !3, line: 4, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "empty-array-3.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -38,4 +38,4 @@ target triple = "x86_64-apple-macosx10.14.0"
 !16 = !{i32 2, !"Debug Info Version", i32 3}
 !17 = !{i32 1, !"wchar_size", i32 4}
 !18 = !{i32 7, !"PIC Level", i32 2}
-!19 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!19 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}

--- a/frontend/llvm/test/regression/import/no_optimization/empty-function-body.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/empty-function-body.ll
@@ -24,14 +24,14 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "empty-function-body.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "GEN2_w_test2_terminate", scope: !1, file: !1, line: 1, type: !9, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{null}

--- a/frontend/llvm/test/regression/import/no_optimization/file-intrinsics.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/file-intrinsics.ll
@@ -146,14 +146,14 @@ attributes #2 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "file-intrinsics.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !9, scopeLine: 3, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/no_optimization/flexible-array-member.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/flexible-array-member.ll
@@ -39,7 +39,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "l", scope: !2, file: !3, line: 6, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "flexible-array-member.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -56,7 +56,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !16 = !{i32 2, !"Debug Info Version", i32 3}
 !17 = !{i32 1, !"wchar_size", i32 4}
 !18 = !{i32 7, !"PIC Level", i32 2}
-!19 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!19 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !20 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 8, type: !21, scopeLine: 8, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !21 = !DISubroutineType(types: !22)
 !22 = !{!9}

--- a/frontend/llvm/test/regression/import/no_optimization/gv-init.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/gv-init.ll
@@ -217,7 +217,7 @@ attributes #1 = { nounwind readnone speculatable }
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "b", scope: !2, file: !3, line: 2, type: !16, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "gv-init.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !4 = !{}
 !5 = !{!0, !6, !9, !14}
@@ -238,7 +238,7 @@ attributes #1 = { nounwind readnone speculatable }
 !20 = !{i32 2, !"Debug Info Version", i32 3}
 !21 = !{i32 1, !"wchar_size", i32 4}
 !22 = !{i32 7, !"PIC Level", i32 2}
-!23 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!23 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !24 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 7, type: !25, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !25 = !DISubroutineType(types: !26)
 !26 = !{!8, !8, !27}

--- a/frontend/llvm/test/regression/import/no_optimization/linked-list.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/linked-list.ll
@@ -53,7 +53,7 @@ attributes #1 = { nounwind readnone speculatable }
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "head", scope: !2, file: !3, line: 6, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "linked-list.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -67,7 +67,7 @@ attributes #1 = { nounwind readnone speculatable }
 !13 = !{i32 2, !"Debug Info Version", i32 3}
 !14 = !{i32 1, !"wchar_size", i32 4}
 !15 = !{i32 7, !"PIC Level", i32 2}
-!16 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!16 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !17 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 8, type: !18, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !18 = !DISubroutineType(types: !19)
 !19 = !{!9, !9, !20}

--- a/frontend/llvm/test/regression/import/no_optimization/local-array-1.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/local-array-1.ll
@@ -114,14 +114,14 @@ attributes #2 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "local-array-1.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 6, type: !9, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11, !12}

--- a/frontend/llvm/test/regression/import/no_optimization/local-array-2.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/local-array-2.ll
@@ -171,14 +171,14 @@ attributes #3 = { argmemonly nounwind }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "local-array-2.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 4, type: !9, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11, !13}

--- a/frontend/llvm/test/regression/import/no_optimization/mem-intrinsics.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/mem-intrinsics.ll
@@ -105,7 +105,7 @@ attributes #2 = { argmemonly nounwind }
 !llvm.module.flags = !{!6, !7, !8, !9}
 !llvm.ident = !{!10}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, retainedTypes: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, retainedTypes: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "mem-intrinsics.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{!4}
@@ -115,7 +115,7 @@ attributes #2 = { argmemonly nounwind }
 !7 = !{i32 2, !"Debug Info Version", i32 3}
 !8 = !{i32 1, !"wchar_size", i32 4}
 !9 = !{i32 7, !"PIC Level", i32 2}
-!10 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!10 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !11 = distinct !DISubprogram(name: "cst", scope: !1, file: !1, line: 3, type: !12, scopeLine: 3, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !12 = !DISubroutineType(types: !13)
 !13 = !{!5}

--- a/frontend/llvm/test/regression/import/no_optimization/multiple-inheritance.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/multiple-inheritance.ll
@@ -41,7 +41,7 @@ attributes #0 = { noinline norecurse nounwind ssp uwtable "correctly-rounded-div
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "c", scope: !2, file: !3, line: 21, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "multiple-inheritance.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -73,7 +73,7 @@ attributes #0 = { noinline norecurse nounwind ssp uwtable "correctly-rounded-div
 !31 = !{i32 2, !"Debug Info Version", i32 3}
 !32 = !{i32 1, !"wchar_size", i32 4}
 !33 = !{i32 7, !"PIC Level", i32 2}
-!34 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!34 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !35 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 23, type: !36, scopeLine: 23, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !36 = !DISubroutineType(types: !37)
 !37 = !{!12}

--- a/frontend/llvm/test/regression/import/no_optimization/nested-struct.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/nested-struct.ll
@@ -59,14 +59,14 @@ attributes #3 = { allocsize(0) }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "nested-struct.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 7, type: !9, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11, !12}

--- a/frontend/llvm/test/regression/import/no_optimization/noexcept.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/noexcept.ll
@@ -76,14 +76,14 @@ attributes #4 = { nounwind }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "noexcept.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "g", linkageName: "_Z1gv", scope: !1, file: !1, line: 3, type: !9, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/no_optimization/non-term-1.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/non-term-1.ll
@@ -79,14 +79,14 @@ attributes #3 = { noreturn }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "non-term-1.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !9, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11, !12}

--- a/frontend/llvm/test/regression/import/no_optimization/non-term-2.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/non-term-2.ll
@@ -47,14 +47,14 @@ attributes #1 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "non-term-2.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !9, scopeLine: 3, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/no_optimization/nullptr.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/nullptr.ll
@@ -50,14 +50,14 @@ attributes #2 = { noinline norecurse nounwind ssp uwtable "correctly-rounded-div
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "nullptr.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "f", linkageName: "_Z1fDn", scope: !1, file: !1, line: 1, type: !9, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !12}

--- a/frontend/llvm/test/regression/import/no_optimization/opaque-struct.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/opaque-struct.ll
@@ -40,7 +40,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "s", scope: !2, file: !3, line: 10, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "opaque-struct.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -57,7 +57,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !16 = !{i32 2, !"Debug Info Version", i32 3}
 !17 = !{i32 1, !"wchar_size", i32 4}
 !18 = !{i32 7, !"PIC Level", i32 2}
-!19 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!19 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !20 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 12, type: !21, scopeLine: 12, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !21 = !DISubroutineType(types: !22)
 !22 = !{!11}

--- a/frontend/llvm/test/regression/import/no_optimization/phi-1.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/phi-1.ll
@@ -113,7 +113,7 @@ attributes #1 = { nounwind readnone speculatable }
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "a", scope: !2, file: !3, line: 1, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "phi-1.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -125,7 +125,7 @@ attributes #1 = { nounwind readnone speculatable }
 !11 = !{i32 2, !"Debug Info Version", i32 3}
 !12 = !{i32 1, !"wchar_size", i32 4}
 !13 = !{i32 7, !"PIC Level", i32 2}
-!14 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!14 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !15 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 3, type: !16, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !16 = !DISubroutineType(types: !17)
 !17 = !{!18, !18, !19}

--- a/frontend/llvm/test/regression/import/no_optimization/phi-2.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/phi-2.ll
@@ -272,14 +272,14 @@ attributes #2 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "phi-2.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 18, type: !9, scopeLine: 18, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11, !12}

--- a/frontend/llvm/test/regression/import/no_optimization/phi-3.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/phi-3.ll
@@ -285,14 +285,14 @@ attributes #2 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "phi-3.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !12, !12, !12}

--- a/frontend/llvm/test/regression/import/no_optimization/phi-4.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/phi-4.ll
@@ -148,14 +148,14 @@ attributes #1 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "phi-4.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 1, type: !9, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11, !12}

--- a/frontend/llvm/test/regression/import/no_optimization/pod-types.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/pod-types.ll
@@ -133,7 +133,7 @@ attributes #2 = { argmemonly nounwind }
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "i", scope: !2, file: !3, line: 1, type: !29, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "pod-types.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !4 = !{}
 !5 = !{!0, !6, !9, !12, !15, !19, !22}
@@ -165,7 +165,7 @@ attributes #2 = { argmemonly nounwind }
 !31 = !{i32 2, !"Debug Info Version", i32 3}
 !32 = !{i32 1, !"wchar_size", i32 4}
 !33 = !{i32 7, !"PIC Level", i32 2}
-!34 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!34 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !35 = distinct !DISubprogram(name: "fun", scope: !3, file: !3, line: 15, type: !36, scopeLine: 15, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !36 = !DISubroutineType(types: !37)
 !37 = !{null}

--- a/frontend/llvm/test/regression/import/no_optimization/pointer-arithmetic.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/pointer-arithmetic.ll
@@ -111,7 +111,7 @@ attributes #2 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ptr_fun", scope: !2, file: !3, line: 7, type: !26, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "pointer-arithmetic.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !4 = !{}
 !5 = !{!0, !6, !14, !23}
@@ -141,7 +141,7 @@ attributes #2 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-
 !29 = !{i32 2, !"Debug Info Version", i32 3}
 !30 = !{i32 1, !"wchar_size", i32 4}
 !31 = !{i32 7, !"PIC Level", i32 2}
-!32 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!32 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !33 = distinct !DISubprogram(name: "f", linkageName: "_Z1fv", scope: !3, file: !3, line: 3, type: !34, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !34 = !DISubroutineType(types: !35)
 !35 = !{!20}

--- a/frontend/llvm/test/regression/import/no_optimization/ptr-to-int.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/ptr-to-int.ll
@@ -34,7 +34,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "x", scope: !2, file: !3, line: 7, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "ptr-to-int.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -45,7 +45,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !10 = !{i32 2, !"Debug Info Version", i32 3}
 !11 = !{i32 1, !"wchar_size", i32 4}
 !12 = !{i32 7, !"PIC Level", i32 2}
-!13 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!13 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !14 = distinct !DISubprogram(name: "f", scope: !3, file: !3, line: 3, type: !15, scopeLine: 3, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !15 = !DISubroutineType(types: !16)
 !16 = !{!17}

--- a/frontend/llvm/test/regression/import/no_optimization/reference.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/reference.ll
@@ -61,14 +61,14 @@ attributes #2 = { noinline norecurse nounwind ssp uwtable "correctly-rounded-div
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "reference.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "f", linkageName: "_Z1fRi", scope: !1, file: !1, line: 1, type: !9, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{null, !11}

--- a/frontend/llvm/test/regression/import/no_optimization/select.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/select.ll
@@ -72,7 +72,7 @@ attributes #0 = { noinline norecurse nounwind ssp uwtable "correctly-rounded-div
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "a", scope: !2, file: !3, line: 8, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "select.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -81,7 +81,7 @@ attributes #0 = { noinline norecurse nounwind ssp uwtable "correctly-rounded-div
 !8 = !{i32 2, !"Debug Info Version", i32 3}
 !9 = !{i32 1, !"wchar_size", i32 4}
 !10 = !{i32 7, !"PIC Level", i32 2}
-!11 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!11 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !12 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 10, type: !13, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !13 = !DISubroutineType(types: !14)
 !14 = !{!6}

--- a/frontend/llvm/test/regression/import/no_optimization/shufflevector.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/shufflevector.ll
@@ -97,7 +97,7 @@ attributes #2 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-
 !llvm.module.flags = !{!11, !12, !13, !14}
 !llvm.ident = !{!15}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, retainedTypes: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, retainedTypes: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "shufflevector.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{!4, !10}
@@ -112,7 +112,7 @@ attributes #2 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-
 !12 = !{i32 2, !"Debug Info Version", i32 3}
 !13 = !{i32 1, !"wchar_size", i32 4}
 !14 = !{i32 7, !"PIC Level", i32 2}
-!15 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!15 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !16 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 5, type: !17, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !17 = !DISubroutineType(types: !18)
 !18 = !{!19, !19, !20}

--- a/frontend/llvm/test/regression/import/no_optimization/struct-parameters.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/struct-parameters.ll
@@ -80,14 +80,14 @@ attributes #2 = { argmemonly nounwind }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "struct-parameters.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "f", scope: !1, file: !1, line: 9, type: !9, scopeLine: 9, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !21}

--- a/frontend/llvm/test/regression/import/no_optimization/thread-local.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/thread-local.ll
@@ -52,7 +52,7 @@ attributes #1 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "x", linkageName: "_ZL1x", scope: !2, file: !3, line: 1, type: !6, isLocal: true, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "thread-local.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -61,7 +61,7 @@ attributes #1 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !8 = !{i32 2, !"Debug Info Version", i32 3}
 !9 = !{i32 1, !"wchar_size", i32 4}
 !10 = !{i32 7, !"PIC Level", i32 2}
-!11 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!11 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !12 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 3, type: !13, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !13 = !DISubroutineType(types: !14)
 !14 = !{!6}

--- a/frontend/llvm/test/regression/import/no_optimization/try-catch.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/try-catch.ll
@@ -599,7 +599,7 @@ attributes #5 = { nounwind }
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "G", scope: !2, file: !3, line: 1, type: !6, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "try-catch.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !4 = !{}
 !5 = !{!0}
@@ -608,7 +608,7 @@ attributes #5 = { nounwind }
 !8 = !{i32 2, !"Debug Info Version", i32 3}
 !9 = !{i32 1, !"wchar_size", i32 4}
 !10 = !{i32 7, !"PIC Level", i32 2}
-!11 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!11 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !12 = distinct !DISubprogram(name: "h", linkageName: "_Z1hi", scope: !3, file: !3, line: 21, type: !13, scopeLine: 21, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !13 = !DISubroutineType(types: !14)
 !14 = !{null, !6}

--- a/frontend/llvm/test/regression/import/no_optimization/undef.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/undef.ll
@@ -56,14 +56,14 @@ attributes #1 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "undef.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !9, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11, !12}

--- a/frontend/llvm/test/regression/import/no_optimization/union.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/union.ll
@@ -51,14 +51,14 @@ attributes #2 = { argmemonly nounwind }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "union.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 6, type: !9, scopeLine: 6, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/no_optimization/var-args.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/var-args.ll
@@ -297,7 +297,7 @@ attributes #5 = { allocsize(0) }
 !llvm.module.flags = !{!6, !7, !8, !9}
 !llvm.ident = !{!10}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, retainedTypes: !3, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, retainedTypes: !3, nameTableKind: GNU)
 !1 = !DIFile(filename: "var-args.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{!4}
@@ -307,7 +307,7 @@ attributes #5 = { allocsize(0) }
 !7 = !{i32 2, !"Debug Info Version", i32 3}
 !8 = !{i32 1, !"wchar_size", i32 4}
 !9 = !{i32 7, !"PIC Level", i32 2}
-!10 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!10 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !11 = distinct !DISubprogram(name: "PrintInts", scope: !1, file: !1, line: 8, type: !12, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !12 = !DISubroutineType(types: !13)
 !13 = !{null, !14, null}

--- a/frontend/llvm/test/regression/import/no_optimization/vector-1.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/vector-1.ll
@@ -59,7 +59,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "a", scope: !2, file: !3, line: 3, type: !8, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "vector-1.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !4 = !{}
 !5 = !{!0, !6, !13}
@@ -76,7 +76,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !16 = !{i32 2, !"Debug Info Version", i32 3}
 !17 = !{i32 1, !"wchar_size", i32 4}
 !18 = !{i32 7, !"PIC Level", i32 2}
-!19 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!19 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !20 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 5, type: !21, scopeLine: 5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !21 = !DISubroutineType(types: !22)
 !22 = !{!23}

--- a/frontend/llvm/test/regression/import/no_optimization/vector-2.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/vector-2.ll
@@ -59,7 +59,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "a", scope: !2, file: !3, line: 3, type: !8, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "vector-2.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !4 = !{}
 !5 = !{!0, !6, !13}
@@ -76,7 +76,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !16 = !{i32 2, !"Debug Info Version", i32 3}
 !17 = !{i32 1, !"wchar_size", i32 4}
 !18 = !{i32 7, !"PIC Level", i32 2}
-!19 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!19 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !20 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 5, type: !21, scopeLine: 5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !21 = !DISubroutineType(types: !22)
 !22 = !{!23}

--- a/frontend/llvm/test/regression/import/no_optimization/vector-3.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/vector-3.ll
@@ -62,7 +62,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "a", scope: !2, file: !3, line: 3, type: !8, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: GNU)
 !3 = !DIFile(filename: "vector-3.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !4 = !{}
 !5 = !{!0, !6, !13}
@@ -79,7 +79,7 @@ attributes #0 = { noinline nounwind ssp uwtable "correctly-rounded-divide-sqrt-f
 !16 = !{i32 2, !"Debug Info Version", i32 3}
 !17 = !{i32 1, !"wchar_size", i32 4}
 !18 = !{i32 7, !"PIC Level", i32 2}
-!19 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!19 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !20 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 5, type: !21, scopeLine: 5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !21 = !DISubroutineType(types: !22)
 !22 = !{!10}

--- a/frontend/llvm/test/regression/import/no_optimization/vector-4.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/vector-4.ll
@@ -41,14 +41,14 @@ attributes #1 = { nounwind readnone speculatable }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "vector-4.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "f", scope: !1, file: !1, line: 3, type: !9, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11, !11}

--- a/frontend/llvm/test/regression/import/no_optimization/virtual-inheritance.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/virtual-inheritance.ll
@@ -637,14 +637,14 @@ attributes #3 = { nounwind }
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "virtual-inheritance.cpp", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 33, type: !9, scopeLine: 33, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{!11}

--- a/frontend/llvm/test/regression/import/no_optimization/vla.ll
+++ b/frontend/llvm/test/regression/import/no_optimization/vla.ll
@@ -175,14 +175,14 @@ attributes #3 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-
 !llvm.module.flags = !{!3, !4, !5, !6}
 !llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (tags/RELEASE_900/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 10.0.0 (tags/RELEASE_1000/final)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: GNU)
 !1 = !DIFile(filename: "vla.c", directory: "/Users/marthaud/ikos/ikos-git/frontend/llvm/test/regression/import/no_optimization")
 !2 = !{}
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (tags/RELEASE_900/final)"}
+!7 = !{!"clang version 10.0.0 (tags/RELEASE_1000/final)"}
 !8 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 2, type: !9, scopeLine: 2, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !10)
 !10 = !{null, !11}

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -41,7 +41,7 @@
 # UNILATERAL TERMINATION OF THIS AGREEMENT.
 #
 ################################################################################
-# 
+#
 # This script assumes the operating system provides:
 #   bash, basename, dirname, mkdir, touch, sed, date
 #
@@ -98,8 +98,8 @@ tbb_install_version="11009"
 python2_required_version="2.7.3"
 python3_required_version="3.3"
 python_install_version="2.7.16"
-llvm_required_version="9"
-llvm_install_version="9.0.0"
+llvm_required_version="10"
+llvm_install_version="10.0.0"
 
 # Default parameters
 install_dir=""
@@ -1725,7 +1725,7 @@ if (( ! found_ppl )); then
 --- src/Determinate_inlines.hh
 +++ src/Determinate_inlines.hh
 @@ -289,8 +289,8 @@ operator()(Determinate& x, const Determinate& y) const {
- 
+
  template <typename PSET>
  template <typename Binary_Operator_Assign>
 -inline
@@ -1738,7 +1738,7 @@ if (( ! found_ppl )); then
 --- src/OR_Matrix_inlines.hh
 +++ src/OR_Matrix_inlines.hh
 @@ -97,7 +97,7 @@ OR_Matrix<T>::Pseudo_Row<U>::Pseudo_Row(const Pseudo_Row<V>& y)
- 
+
  template <typename T>
  template <typename U>
 -inline OR_Matrix<T>::Pseudo_Row<U>&

--- a/test/install/archlinux/Dockerfile
+++ b/test/install/archlinux/Dockerfile
@@ -13,8 +13,8 @@ ARG build_type=Release
 # python 3.8
 # sqlite 3.30.1
 # tbb 11009
-# llvm 9.0.0
-# clang 9.0.0
+# llvm 10.0.0
+# clang 10.0.0
 # gcc 9.2.0
 
 # Upgrade

--- a/test/install/centos-6/Dockerfile
+++ b/test/install/centos-6/Dockerfile
@@ -13,8 +13,8 @@ ARG build_type=Release
 # python 2.7.16
 # sqlite 3.6.20
 # tbb 4001
-# llvm 9.0.0
-# clang 9.0.0
+# llvm 10.0.0
+# clang 10.0.0
 # gcc 8.3.1
 
 # Upgrade

--- a/test/install/centos-7/Dockerfile
+++ b/test/install/centos-7/Dockerfile
@@ -13,8 +13,8 @@ ARG build_type=Release
 # python 2.7.5
 # sqlite 3.7.17
 # tbb 6103
-# llvm 9.0.0
-# clang 9.0.0
+# llvm 10.0.0
+# clang 10.0.0
 # gcc 8.3.1
 
 # Upgrade

--- a/test/install/debian-10/Dockerfile
+++ b/test/install/debian-10/Dockerfile
@@ -10,16 +10,16 @@ ARG build_type=Release
 # python 2.7.16
 # sqlite 3.27.2
 # tbb 10006
-# llvm 9.0.1
-# clang 9.0.1
+# llvm 10.0.1
+# clang 10.0.1
 # gcc 8.3.0
 
 # Upgrade
 RUN apt-get update
 RUN apt-get upgrade -y
 
-# Add ppa for llvm 9.0
-RUN echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-9 main" >> /etc/apt/sources.list
+# Add ppa for llvm 10.0
+RUN echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-10 main" >> /etc/apt/sources.list
 
 # Add llvm repository key
 RUN apt-get install -y wget gnupg
@@ -32,7 +32,7 @@ RUN apt-get update
 RUN apt-get install -y gcc g++ cmake libgmp-dev libboost-dev \
         libboost-filesystem-dev libboost-thread-dev libboost-test-dev python \
         python-pygments libsqlite3-dev libtbb-dev libz-dev libedit-dev \
-        llvm-9 llvm-9-dev llvm-9-tools clang-9
+        llvm-10 llvm-10-dev llvm-10-tools clang-10
 
 # Add ikos source code
 ADD . /root/ikos
@@ -44,7 +44,7 @@ ENV MAKEFLAGS "-j$njobs"
 RUN cmake \
         -DCMAKE_INSTALL_PREFIX="/opt/ikos" \
         -DCMAKE_BUILD_TYPE="$build_type" \
-        -DLLVM_CONFIG_EXECUTABLE="/usr/lib/llvm-9/bin/llvm-config" \
+        -DLLVM_CONFIG_EXECUTABLE="/usr/lib/llvm-10/bin/llvm-config" \
         ..
 RUN make
 RUN make install

--- a/test/install/debian-9/Dockerfile
+++ b/test/install/debian-9/Dockerfile
@@ -10,16 +10,16 @@ ARG build_type=Release
 # python 2.7.13
 # sqlite 3.16.2
 # tbb 8006
-# llvm 9.0.1
-# clang 9.0.1
+# llvm 10.0.1
+# clang 10.0.1
 # gcc 6.3.0
 
 # Upgrade
 RUN apt-get update
 RUN apt-get upgrade -y
 
-# Add ppa for llvm 9.0
-RUN echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch-9 main" >> /etc/apt/sources.list
+# Add ppa for llvm 10.0
+RUN echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch-10 main" >> /etc/apt/sources.list
 
 # Add llvm repository key
 RUN apt-get install -y wget gnupg
@@ -32,7 +32,7 @@ RUN apt-get update
 RUN apt-get install -y gcc g++ cmake libgmp-dev libboost-dev \
         libboost-filesystem-dev libboost-thread-dev libboost-test-dev python \
         python-pygments libsqlite3-dev libtbb-dev libz-dev libedit-dev \
-        llvm-9 llvm-9-dev llvm-9-tools clang-9
+        llvm-10 llvm-10-dev llvm-10-tools clang-10
 
 # Add ikos source code
 ADD . /root/ikos
@@ -44,7 +44,7 @@ ENV MAKEFLAGS "-j$njobs"
 RUN cmake \
         -DCMAKE_INSTALL_PREFIX="/opt/ikos" \
         -DCMAKE_BUILD_TYPE="$build_type" \
-        -DLLVM_CONFIG_EXECUTABLE="/usr/lib/llvm-9/bin/llvm-config" \
+        -DLLVM_CONFIG_EXECUTABLE="/usr/lib/llvm-10/bin/llvm-config" \
         ..
 RUN make
 RUN make install

--- a/test/install/fedora-29/Dockerfile
+++ b/test/install/fedora-29/Dockerfile
@@ -13,8 +13,8 @@ ARG build_type=Release
 # python 2.7.17
 # sqlite 3.26.0
 # tbb 10005
-# llvm 9.0.0
-# clang 9.0.0
+# llvm 10.0.0
+# clang 10.0.0
 # gcc 8.3.1
 
 # Upgrade

--- a/test/install/fedora-30/Dockerfile
+++ b/test/install/fedora-30/Dockerfile
@@ -13,8 +13,8 @@ ARG build_type=Release
 # python 2.7.17
 # sqlite 3.26.0
 # tbb 11008
-# llvm 9.0.0
-# clang 9.0.0
+# llvm 10.0.0
+# clang 10.0.0
 # gcc 9.2.1
 
 # Upgrade

--- a/test/install/rhel-6/Dockerfile
+++ b/test/install/rhel-6/Dockerfile
@@ -15,8 +15,8 @@ ARG rhel_password
 # python 3.4.10
 # sqlite 3.6.20
 # tbb 4001
-# llvm 9.0.0
-# clang 9.0.0
+# llvm 10.0.0
+# clang 10.0.0
 # gcc 9.2.0
 
 # Subscribe

--- a/test/install/rhel-7/Dockerfile
+++ b/test/install/rhel-7/Dockerfile
@@ -15,8 +15,8 @@ ARG rhel_password
 # python 2.7.5
 # sqlite 3.7.17
 # tbb 6103
-# llvm 9.0.0
-# clang 9.0.0
+# llvm 10.0.0
+# clang 10.0.0
 # gcc 9.2.0
 
 # Subscribe

--- a/test/install/ubuntu-16.04/Dockerfile
+++ b/test/install/ubuntu-16.04/Dockerfile
@@ -10,16 +10,16 @@ ARG build_type=Release
 # python 2.7.12
 # sqlite 3.11.0
 # tbb 9002
-# llvm 9.0.1
-# clang 9.0.1
+# llvm 10.0.1
+# clang 10.0.1
 # gcc 5.4.0
 
 # Upgrade
 RUN apt-get update
 RUN apt-get upgrade -y
 
-# Add ppa for llvm 9.0
-RUN echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main" >> /etc/apt/sources.list
+# Add ppa for llvm 10.0
+RUN echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main" >> /etc/apt/sources.list
 
 # Add llvm repository key
 RUN apt-get install -y wget gnupg
@@ -32,7 +32,7 @@ RUN apt-get update
 RUN apt-get install -y gcc g++ cmake libgmp-dev libboost-dev \
         libboost-filesystem-dev libboost-thread-dev libboost-test-dev python \
         python-pygments libsqlite3-dev libtbb-dev libz-dev libedit-dev \
-        llvm-9 llvm-9-dev llvm-9-tools clang-9
+        llvm-10 llvm-10-dev llvm-10-tools clang-10
 
 # Add ikos source code
 ADD . /root/ikos
@@ -44,7 +44,7 @@ ENV MAKEFLAGS "-j$njobs"
 RUN cmake \
         -DCMAKE_INSTALL_PREFIX="/opt/ikos" \
         -DCMAKE_BUILD_TYPE="$build_type" \
-        -DLLVM_CONFIG_EXECUTABLE="/usr/lib/llvm-9/bin/llvm-config" \
+        -DLLVM_CONFIG_EXECUTABLE="/usr/lib/llvm-10/bin/llvm-config" \
         ..
 RUN make
 RUN make install

--- a/test/install/ubuntu-18.04/Dockerfile
+++ b/test/install/ubuntu-18.04/Dockerfile
@@ -10,16 +10,16 @@ ARG build_type=Release
 # python 2.7.15
 # sqlite 3.22.0
 # tbb 9107
-# llvm 9.0.1
-# clang 9.0.1
+# llvm 10.0.1
+# clang 10.0.1
 # gcc 7.4.0
 
 # Upgrade
 RUN apt-get update
 RUN apt-get upgrade -y
 
-# Add ppa for llvm 9.0
-RUN echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main" >> /etc/apt/sources.list
+# Add ppa for llvm 10.0
+RUN echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main" >> /etc/apt/sources.list
 
 # Add llvm repository key
 RUN apt-get install -y wget gnupg
@@ -32,7 +32,7 @@ RUN apt-get update
 RUN apt-get install -y gcc g++ cmake libgmp-dev libboost-dev \
         libboost-filesystem-dev libboost-thread-dev libboost-test-dev python \
         python-pygments libsqlite3-dev libtbb-dev libz-dev libedit-dev \
-        llvm-9 llvm-9-dev llvm-9-tools clang-9
+        llvm-10 llvm-10-dev llvm-10-tools clang-10
 
 # Add ikos source code
 ADD . /root/ikos
@@ -44,7 +44,7 @@ ENV MAKEFLAGS "-j$njobs"
 RUN cmake \
         -DCMAKE_INSTALL_PREFIX="/opt/ikos" \
         -DCMAKE_BUILD_TYPE="$build_type" \
-        -DLLVM_CONFIG_EXECUTABLE="/usr/lib/llvm-9/bin/llvm-config" \
+        -DLLVM_CONFIG_EXECUTABLE="/usr/lib/llvm-10/bin/llvm-config" \
         ..
 RUN make
 RUN make install

--- a/test/install/ubuntu-19.04/Dockerfile
+++ b/test/install/ubuntu-19.04/Dockerfile
@@ -10,16 +10,16 @@ ARG build_type=Release
 # python 2.7.16
 # sqlite 3.27.2
 # tbb 10006
-# llvm 9.0.1
-# clang 9.0.1
+# llvm 10.0.1
+# clang 10.0.1
 # gcc 8.3.0
 
 # Upgrade
 RUN apt-get update
 RUN apt-get upgrade -y
 
-# Add ppa for llvm 9.0
-RUN echo "deb http://apt.llvm.org/disco/ llvm-toolchain-disco-9 main" >> /etc/apt/sources.list
+# Add ppa for llvm 10.0
+RUN echo "deb http://apt.llvm.org/disco/ llvm-toolchain-disco-10 main" >> /etc/apt/sources.list
 
 # Add llvm repository key
 RUN apt-get install -y wget gnupg
@@ -32,7 +32,7 @@ RUN apt-get update
 RUN apt-get install -y gcc g++ cmake libgmp-dev libboost-dev \
         libboost-filesystem-dev libboost-thread-dev libboost-test-dev python \
         python-pygments libsqlite3-dev libtbb-dev libz-dev libedit-dev \
-        llvm-9 llvm-9-dev llvm-9-tools clang-9
+        llvm-10 llvm-10-dev llvm-10-tools clang-10
 
 # Add ikos source code
 ADD . /root/ikos
@@ -44,7 +44,7 @@ ENV MAKEFLAGS "-j$njobs"
 RUN cmake \
         -DCMAKE_INSTALL_PREFIX="/opt/ikos" \
         -DCMAKE_BUILD_TYPE="$build_type" \
-        -DLLVM_CONFIG_EXECUTABLE="/usr/lib/llvm-9/bin/llvm-config" \
+        -DLLVM_CONFIG_EXECUTABLE="/usr/lib/llvm-10/bin/llvm-config" \
         ..
 RUN make
 RUN make install


### PR DESCRIPTION
Hi @arthaud,

This patch also supports LLVM 9, due to test reason.

This PR is very naive version for supporting LLVM 11. IMHO, you have wanted to separate IKOS and LLVM layers for various reasons. In that sense, I think this patch is not enough for your intention. So I would like to need your feedbacks to update it in a right way. I also think this patch should be updated docs and other parts likewise your previous commit(LLVM 9).

Anyway, I passed all test cases on "make check", expected #78 .