### PR TITLE
add instructions for Ubuntu 20.04

### DIFF
--- a/doc/install/UBUNTU_20.04.md
+++ b/doc/install/UBUNTU_20.04.md
@@ -1,0 +1,30 @@
+Install IKOS dependencies on Ubuntu 20.04
+=========================================
+
+Here are the steps to install the required dependencies of IKOS on **[Ubuntu 20.04 LTS (Focal Fossa)](http://releases.ubuntu.com/20.04/)**.
+
+First, make sure your system is up-to-date: 
+
+```
+$ sudo apt-get update
+$ sudo apt-get upgrade
+```
+
+Then, run the following commands:
+
+```
+$ sudo apt-get install gcc g++ cmake libgmp-dev libboost-dev libboost-filesystem-dev \
+    libboost-thread-dev libboost-test-dev python3 python3-pygments libsqlite3-dev libtbb-dev \
+    libz-dev libedit-dev llvm-9 llvm-9-dev llvm-9-tools clang-9
+```
+
+When running cmake to build IKOS, you will need to define `LLVM_CONFIG_EXECUTABLE`:
+
+```
+$ cmake \
+    -DCMAKE_INSTALL_PREFIX="/path/to/ikos-install-directory" \
+    -DLLVM_CONFIG_EXECUTABLE="/usr/bin/llvm-config-9" \
+    ..
+```
+
+You are now ready to build IKOS. Go to the section [Build and Install](../../README.md#build-and-install) in README.md


### PR DESCRIPTION
Clang/LLVM version 9 is available in the official Ubuntu 20.04 repos, which simplifies the install somewhat. Furthermore, Python2 is not installed per default anymore, hence the change python3 compared to instructions for Ubuntu 19.04.