### PR TITLE
Use `is_alive` instead of `isAlive`

### DIFF
--- a/analyzer/python/ikos/analyzer.py
+++ b/analyzer/python/ikos/analyzer.py
@@ -909,7 +909,7 @@ def ikos_analyzer(db_path, pp_path, opt):
             _, return_status = os.waitpid(p.pid, 0)
     finally:
         # kill the timer if the process has terminated already
-        if timer.isAlive():
+        if timer.is_alive():
             timer.cancel()
 
     # special case for Windows, since it does not define WIFEXITED & co.


### PR DESCRIPTION
`Thread.isAlive()` was removed in Python 3.9 in favor of `Thread.is_alive()`. 

Ideally there's a way to do this without breaking backwards compatibility but I'm unfamiliar with the project and I'm not sure what versions of Python are intended to be supported.

https://github.com/NASA-SW-VnV/ikos/issues/167