### PR TITLE
Added a SARIF output report option

### DIFF
--- a/analyzer/python/ikos/args.py
+++ b/analyzer/python/ikos/args.py
@@ -363,6 +363,7 @@ report_formats = (
     ('auto', 'Generate a text report, if less than 15 entries'),
     ('text', 'Generate a text report'),
     ('json', 'Generate a json report'),
+    ('sarif', 'Generate a sarif report'),
     ('csv', 'Generate a csv report'),
     ('web', 'Generate a web report (ikos-view)'),
     ('no', 'Do not generate a report'),


### PR DESCRIPTION
I modified report.py and args.py in analyzer/python/ikos/ to add and support an option to produce a sarif report out of the result database (use: ikos-report -f sarif ....).