### PR TITLE
added a junit output format for the report

### DIFF
--- a/analyzer/python/ikos/args.py
+++ b/analyzer/python/ikos/args.py
@@ -364,6 +364,7 @@ report_formats = (
     ('text', 'Generate a text report'),
     ('json', 'Generate a json report'),
     ('sarif', 'Generate a sarif report'),
+    ('junit', 'Generate a JUnit.xml report'),
     ('csv', 'Generate a csv report'),
     ('web', 'Generate a web report (ikos-view)'),
     ('no', 'Do not generate a report'),

--- a/analyzer/python/ikos/report.py
+++ b/analyzer/python/ikos/report.py
@@ -1111,9 +1111,8 @@ class JUnitFormatter(Formatter):
         if db:
             results = db.load_timing_results(True, True)
             for result in results:
-                print(result)
                 if result[0] == 'ikos-analyzer':
-                    elapsed = result[1]
+                    return result[1]
         return elapsed
 
     # some messages provided by IKOS are multi-line but 
@@ -1141,7 +1140,6 @@ class JUnitFormatter(Formatter):
             'time': '%.3f' % round(elapsed, 3),
             'skip': 0,
         }
-        print (data)
         xml = """<?xml version="1.0" encoding="UTF-8"?>
 <testsuite
   name="%(testname)s"


### PR DESCRIPTION
It basically adds another output format (JUnit) for the report. This allows for example to pull IKOS results run using Jenkins. The output looks like this:
<?xml version="1.0" encoding="UTF-8"?>
<testsuite
  name=".ikos-analysis-results"
  tests="2216"
  errors="0"
  failures="150"
  time="10.878"
  skipped="0"
> 
  <testcase
    name="warning: ignored-call-side-effect (/home/vagrant/troupe1/apps/cam/fsw/src/cam.cpp:29)"
    classname=".ikos-analysis-results"
  >
      <failure message="ignored side effect of call to extern function '__cxa_atexit'. Analysis might be unsound."/>
  </testcase>
  <testcase
    name="warning: ignored-call-side-effect (/home/vagrant/troupe1/apps/cam/fsw/src/cam.cpp:35)"
    classname=".ikos-analysis-results"
  >
  </testcase>
….
<testcase
    name="warning: ignored-call-side-effect (/home/vagrant/troupe1/apps/cam/fsw/src/cam.cpp:62)"
    classname=".ikos-analysis-results"
  >
      <failure message="ignored side effect of call to extern function 'CFE_EVS_SendEvent'. Analysis might be unsound."/>
  </testcase>
</testsuite>