### PR TITLE
Allow compiler shims to create notification files.

### DIFF
--- a/analyzer/python/ikos/scan.py
+++ b/analyzer/python/ikos/scan.py
@@ -670,8 +670,8 @@ class ScanServer(threading.Thread):
 def compile_main(mode, argv):
     progname = os.path.basename(argv[0])
 
-    if 'IKOS_SCAN_SERVER' not in os.environ and 'IKOS_SCAN_NOTIFIER_FILES' not in os.environ:
-        printf('error: %s: missing environment variable IKOS_SCAN_SERVER.\n',
+    if not ('IKOS_SCAN_SERVER' in os.environ or 'IKOS_SCAN_NOTIFIER_FILES' in os.environ):
+        printf('error: %s: missing environment variable IKOS_SCAN_SERVER or IKOS_SCAN_NOTIFIER_FILES.\n',
                progname, file=sys.stderr)
         sys.exit(1)
 

--- a/analyzer/python/ikos/scan.py
+++ b/analyzer/python/ikos/scan.py
@@ -594,7 +594,8 @@ def notify_binary_built(exe_path, bc_path):
         with open(indicator_path, 'w') as indicator_file:
             indicator_file.write(json.dumps({
                 'exe': abs_exe_path,
-                'bc': abs_bc_path}))
+                'bc': abs_bc_path,
+            }))
     else:
         binary = {
             'exe': os.path.abspath(exe_path),

--- a/analyzer/python/ikos/scan.py
+++ b/analyzer/python/ikos/scan.py
@@ -598,8 +598,8 @@ def notify_binary_built(exe_path, bc_path):
             }))
     else:
         binary = {
-            'exe': os.path.abspath(exe_path),
-            'bc': os.path.abspath(bc_path),
+            'exe': abs_exe_path,
+            'bc': abs_bc_path,
         }
         data = http.urlencode(binary).encode('utf-8')
         http.urlopen(os.environ['IKOS_SCAN_SERVER'], data)


### PR DESCRIPTION
To accommodate our build process, we want to run the ikos compiler shims without running a scan server.
With this patch and a separate environment variable, whenever the compiler shim would have notified the scan server of a binary it will instead create a notification/marker file with information about binary and bc paths, equivalent to what would be sent to the scan server, which we can then use in a process after the build phase to run ikos analysis results without the running HTTP server.

This initial patch is very much a working prototype and I am more than happy to change the names of the environment variables or refactor the internals. We're able to take advantage of this patch's current state in our `ament_ikos` wrapper utility which runs during the test phase of our builds and uses a [brief routine](https://github.com/ament/ament_ikos/blob/73ff35d5c32f10328e7ad5b17903f6c5b6810103/ament_ikos/ament_ikos/main.py#L16-L25) to scan a package's cmake build directory for the marker files created here and run ikos analysis and report generation.