### PR TITLE
Detect dynamic uninitialized variables with debug info optional

### DIFF
--- a/analyzer/include/ikos/analyzer/analysis/execution_engine/numerical.hpp
+++ b/analyzer/include/ikos/analyzer/analysis/execution_engine/numerical.hpp
@@ -263,8 +263,6 @@ public:
       this->_inv.normal().mem_write(ptr,
                                     ScalarLit::undefined(),
                                     alloc_size);
-      this->_inv.normal().nullity_set(ptr, nullity);
-      this->_inv.normal().lifetime_assign_allocated(addr);
     }
 
     if (this->_opts.test(ExecutionEngine::UpdateAllocSizeVar)) {

--- a/analyzer/include/ikos/analyzer/analysis/execution_engine/numerical.hpp
+++ b/analyzer/include/ikos/analyzer/analysis/execution_engine/numerical.hpp
@@ -258,8 +258,9 @@ public:
     // Update pointer, lifetime and initial value for the memory location
     this->allocate_memory(ptr, addr, nullity, lifetime, init_val);
     if (init_val == MemoryInitialValue::Uninitialized) {
-      // Writing undefined will mark it uninitialized,
-      // but then we need to set nullity and lifetime.
+      // When the size of the allocation is known (like it is here)
+      // we mark the storage as uninitialized by assigning it
+      // the undefined value.
       this->_inv.normal().mem_write(ptr,
                                     ScalarLit::undefined(),
                                     alloc_size);

--- a/analyzer/src/analysis/memory_location.cpp
+++ b/analyzer/src/analysis/memory_location.cpp
@@ -65,7 +65,9 @@ LocalMemoryLocation::LocalMemoryLocation(ar::LocalVariable* var)
 }
 
 void LocalMemoryLocation::dump(std::ostream& o) const {
+  o << "LML{";
   this->_var->dump(o);
+  o << "}";
 }
 
 // GlobalMemoryLocation
@@ -76,7 +78,9 @@ GlobalMemoryLocation::GlobalMemoryLocation(ar::GlobalVariable* var)
 }
 
 void GlobalMemoryLocation::dump(std::ostream& o) const {
+  o << "GML{";
   this->_var->dump(o);
+  o << "}";
 }
 
 // FunctionMemoryLocation
@@ -98,7 +102,9 @@ AggregateMemoryLocation::AggregateMemoryLocation(ar::InternalVariable* var)
 }
 
 void AggregateMemoryLocation::dump(std::ostream& o) const {
+  o << "AML{";
   this->_var->dump(o);
+  o << "}";
 }
 
 // AbsoluteZeroMemoryLocation

--- a/analyzer/src/analysis/memory_location.cpp
+++ b/analyzer/src/analysis/memory_location.cpp
@@ -65,7 +65,7 @@ LocalMemoryLocation::LocalMemoryLocation(ar::LocalVariable* var)
 }
 
 void LocalMemoryLocation::dump(std::ostream& o) const {
-  o << "LML{";
+  o << "LocalMemoryLocation{";
   this->_var->dump(o);
   o << "}";
 }
@@ -78,7 +78,7 @@ GlobalMemoryLocation::GlobalMemoryLocation(ar::GlobalVariable* var)
 }
 
 void GlobalMemoryLocation::dump(std::ostream& o) const {
-  o << "GML{";
+  o << "GlobalMemoryLocation{";
   this->_var->dump(o);
   o << "}";
 }
@@ -102,7 +102,7 @@ AggregateMemoryLocation::AggregateMemoryLocation(ar::InternalVariable* var)
 }
 
 void AggregateMemoryLocation::dump(std::ostream& o) const {
-  o << "AML{";
+  o << "AggregateMemoryLocation{";
   this->_var->dump(o);
   o << "}";
 }

--- a/analyzer/src/checker/buffer_overflow.cpp
+++ b/analyzer/src/checker/buffer_overflow.cpp
@@ -783,7 +783,7 @@ BufferOverflowChecker::CheckResult BufferOverflowChecker::check_mem_access(
   if (size.is_undefined() ||
       (size.is_machine_int_var() &&
        inv.normal().uninit_is_uninitialized(size.var()))) {
-    // Undefined pointer operand
+    // Undefined size operand
     if (auto msg = this->display_mem_access_check(Result::Error,
                                                   stmt,
                                                   pointer,

--- a/analyzer/src/checker/uninitialized_variable.cpp
+++ b/analyzer/src/checker/uninitialized_variable.cpp
@@ -73,6 +73,27 @@ void UninitializedVariableChecker::check(ar::Statement* stmt,
     return;
   }
 
+  // Exempt "And" and "Or" if one operand is constant.
+  if (ar::BinaryOperation* inst = dyn_cast< ar::BinaryOperation >(stmt)) {
+    auto op = inst->op();
+    switch (op) {
+      case ar::BinaryOperation::Operator::UAnd:
+      case ar::BinaryOperation::Operator::UOr:
+      case ar::BinaryOperation::Operator::SAnd:
+      case ar::BinaryOperation::Operator::SOr: {
+        auto left = inst->left();
+        auto right = inst->right();
+        if (left->is_integer_constant() || right->is_integer_constant()) {
+          return;
+        }
+        break;
+      }
+      default: {
+        break;
+      }
+    }
+  }
+
   if (auto insert = dyn_cast< ar::InsertElement >(stmt)) {
     // InsertElement accepts undefined aggregate operands
     this->check_initialized(stmt, insert->offset(), inv, call_context);

--- a/analyzer/src/ikos_analyzer.cpp
+++ b/analyzer/src/ikos_analyzer.cpp
@@ -922,9 +922,9 @@ int main(int argc, char** argv) {
     {
       analyzer::log::debug("Checking for debug information");
       if (!llvm_to_ar::has_debug_info(*module)) {
+        // We warn but allow analysis to proceed.
         llvm::errs() << progname << ": " << InputFilename
-                     << ": error: llvm bitcode has no debug information\n";
-        return 4;
+                     << ": warning: llvm bitcode has no debug information\n";
       }
     }
 

--- a/analyzer/test/regression/boa/runtest
+++ b/analyzer/test/regression/boa/runtest
@@ -207,7 +207,7 @@ if __name__ == '__main__':
                             (18, 'warning'),
                             (23, 'warning'),
                             (27, 'warning')]))
-    t.add(Test('test-52.c', 'test-52.c', 'boa', 'error'))
+    t.add(Test('test-52.c', 'test-52.c', ['boa', 'uva'], 'error'))
     t.add(Test('test-53.c', 'test-53.c (interval)', 'boa', 'safe',
                expected='unsafe',
                domain='interval'))
@@ -219,7 +219,7 @@ if __name__ == '__main__':
                expected='unsafe',
                line_checks=[(2, 'ok', 'warning'),
                             (7, 'ok')]))
-    t.add(Test('test-56.cpp', 'test-56.cpp', 'boa', 'error'))
+    t.add(Test('test-56.cpp', 'test-56.cpp', ['boa','uva'], 'error'))
     t.add(Test('astree-ex.c', 'astree-ex.c', 'boa', 'safe',
                expected='unsafe',
                line_checks=[(20, 'ok', 'warning')]))
@@ -245,7 +245,7 @@ if __name__ == '__main__':
     t.add(Test('test-65.c', 'test-65.c (interval)', 'boa', 'safe', expected='unsafe', domain='interval'))
     t.add(Test('test-65.c', 'test-65.c (var-pack-dbm)', 'boa', 'safe', domain='var-pack-dbm'))
     t.add(Test('test-65.c', 'test-65.c (dbm)', 'boa', 'safe', domain='dbm'))
-    t.add(Test('test-66.c', 'test-66.c (interval)', 'boa', 'safe', expected='unsafe', domain='interval'))
+    t.add(Test('test-66.c', 'test-66.c (interval)', ['boa', 'uva'], 'error', domain='interval'))
     t.add(Test('test-66.c', 'test-66.c (var-pack-dbm)', 'boa', 'safe', domain='var-pack-dbm'))
     t.add(Test('test-66.c', 'test-66.c (dbm)', 'boa', 'safe', domain='dbm'))
     t.add(Test('test-67.c', 'test-67.c (interval)', 'boa', 'safe', expected='unsafe', domain='interval'))

--- a/analyzer/test/regression/runalltests
+++ b/analyzer/test/regression/runalltests
@@ -1,0 +1,11 @@
+#!/usr/bin/sh
+for d in `find -type d`
+do
+if test -x "$d/runtest"
+then
+    echo "++++++++++++"
+    echo $d
+    $d/runtest
+fi
+echo ""
+done

--- a/analyzer/test/regression/uva/runtest
+++ b/analyzer/test/regression/uva/runtest
@@ -58,6 +58,7 @@ if __name__ == '__main__':
     t.add(Test('test-2-error-2.c', 'test-2-error-2.c', 'uva', 'error', expected='safe'))
     t.add(Test('test-8-safe.c', 'test-8-safe.c', 'uva', 'safe'))
     t.add(Test('test-8-warning.c', 'test-8-warning.c', 'uva', 'unsafe', expected='safe'))
+    t.add(Test('test-8-warning.c', 'test-8-warning.c (opt_level=none)', 'uva', 'unsafe', opt_level='none'))
     t.add(Test('test-14-safe.c', 'test-14-safe.c', 'uva', 'safe'))
     t.add(Test('test-15-error.c', 'test-15-error.c', 'uva', 'error'))
     t.add(Test('test-16-error.c', 'test-16-error.c', 'uva', 'error'))
@@ -68,4 +69,28 @@ if __name__ == '__main__':
     t.add(Test('test-20-safe.c', 'test-20-safe.c', 'uva', 'safe', opt_level='aggressive'))
     t.add(Test('test-21-safe.cpp', 'test-21-safe.cpp', 'uva', 'safe'))
     t.add(Test('test-21-safe.cpp', 'test-21-safe.cpp', 'uva', 'safe', opt_level='aggressive'))
+    t.add(Test('test-22-error.c', 'test-22-error.c', 'uva', 'error'))
+    t.add(Test('test-23-warning.c', 'test-23-warning.c', 'uva', 'unsafe'))
+    t.add(Test('test-24-error.cpp', 'test-24-error.cpp', 'uva', 'error'))
+    t.add(Test('test-25-warning.c', 'test-25-warning.c', 'uva', 'unsafe', expected='safe'))
+    t.add(Test('test-25-warning.c', 'test-25-warning.c (opt_level=none)', 'uva', 'unsafe', opt_level='none'))
+    t.add(Test('test-26-error.cpp', 'test-26-error.cpp', 'uva', 'error'))
+    t.add(Test('test-27-error.c', 'test-27-error.c', 'uva', 'error'))
+    t.add(Test('test-28-error.cpp', 'test-28-error.cpp', 'uva', 'error'))
+    t.add(Test('test-29-safe.cpp', 'test-29-safe.cpp', 'uva', 'safe', expected='unsafe'))
+    t.add(Test('test-30-safe.c', 'test-30-safe.c', 'uva', 'safe'))
+    t.add(Test('test-31-error.cpp', 'test-31-error.cpp', 'uva', 'error'))
+    t.add(Test('test-32-error.cpp', 'test-32-error.cpp', 'uva', 'error'))
+    # The following test seems to have some debug information mismatch so ignore that.
+    t.add(Test('test-33-error.cpp', 'test-33-error.cpp', 'uva', 'error', options=['-allow-dbg-mismatch']))
+    # In the following 2 test there are warnings coming from the standard library.
+    # A future PR to IKOS may contain the ability to filter these out so that
+    # the focus is on the user code. This test has no warnings in user code.
+    t.add(Test('test-34-safe.cpp', 'test-34-safe.cpp', 'uva', 'safe', expected='unsafe'))
+    t.add(Test('test-35-safe.cpp', 'test-35-safe.cpp', 'uva', 'safe', expected='unsafe'))
+    # The following test is really an error but current analysis is only giving warning.
+    t.add(Test('test-36-error.cpp', 'test-36-error.cpp', 'uva', 'error', expected='unsafe'))
+    t.add(Test('test-37-error.cpp', 'test-37-error.cpp', 'uva', 'error'))
+    t.add(Test('test-38-safe.cpp', 'test-38-safe.cpp', 'uva', 'safe'))
+    t.add(Test('test-39-error.cpp', 'test-39-error.cpp', 'uva', 'error'))
     t.run()

--- a/analyzer/test/regression/uva/test-22-error.c
+++ b/analyzer/test/regression/uva/test-22-error.c
@@ -1,0 +1,8 @@
+#include <stdlib.h>
+int main() {
+  int* p = (int*)malloc(sizeof(int));
+  if (!p) {
+    return 0;
+  }
+  return *p + 5;
+}

--- a/analyzer/test/regression/uva/test-23-warning.c
+++ b/analyzer/test/regression/uva/test-23-warning.c
@@ -1,0 +1,14 @@
+#include <stdlib.h>
+int main(int argc, char** argv) {
+  int* p = NULL;
+  int x = 0;
+  p = malloc(sizeof(int)); // uninitialized
+  if (!p) {
+    return 0;
+  }
+  if (argc) {
+    p = &x;
+  }
+  int y = *p; // initialized if p = &x but uninitialized if p = malloc(..)
+  return y;
+}

--- a/analyzer/test/regression/uva/test-24-error.cpp
+++ b/analyzer/test/regression/uva/test-24-error.cpp
@@ -1,0 +1,6 @@
+int main(int argc, char *argv[])
+{
+  int myray[2];
+  myray[1] = 5;
+  return myray[0];
+}

--- a/analyzer/test/regression/uva/test-25-warning.c
+++ b/analyzer/test/regression/uva/test-25-warning.c
@@ -1,0 +1,8 @@
+int main(int argc, char** argv)
+{
+  int ivar;
+  if(argc > 1) {
+    ivar = 5;
+  }
+  return ivar;
+}

--- a/analyzer/test/regression/uva/test-26-error.cpp
+++ b/analyzer/test/regression/uva/test-26-error.cpp
@@ -1,0 +1,5 @@
+#include <cstdlib>
+int main() {
+  int* p = new int;
+  return *p;
+}

--- a/analyzer/test/regression/uva/test-27-error.c
+++ b/analyzer/test/regression/uva/test-27-error.c
@@ -1,0 +1,5 @@
+int main()
+{
+  int* ivar;
+  return *ivar;
+}

--- a/analyzer/test/regression/uva/test-28-error.cpp
+++ b/analyzer/test/regression/uva/test-28-error.cpp
@@ -1,0 +1,22 @@
+#include <memory>
+
+struct MyStruct {
+  int _aa;
+  int _bb;
+  MyStruct() noexcept
+  {
+    //_aa = 5;
+    _bb = 7;
+  }
+};
+
+int main(int argc, char *argv[])
+{
+    MyStruct* test1 = nullptr;
+    int i = 0;
+    do {
+        test1 = new MyStruct;
+        i++;
+    }while (i < 2);
+    return test1->_aa;
+}

--- a/analyzer/test/regression/uva/test-29-safe.cpp
+++ b/analyzer/test/regression/uva/test-29-safe.cpp
@@ -1,0 +1,23 @@
+#include <memory>
+
+struct MyStruct {
+  int _aa;
+  int _bb;
+  MyStruct() noexcept
+  {
+    _aa = 5;
+    _bb = 7;
+  }
+};
+
+int main(int argc, char *argv[])
+{
+  // This test gives a false positive because the ikos AR
+  // does not assure that the body is executed at least once.
+  // That could probably be fixed.
+  MyStruct* test1 = nullptr;
+  for(int i = 0; i < 2;i++) {
+    test1 = new MyStruct;
+  }
+  return test1->_aa;
+}

--- a/analyzer/test/regression/uva/test-30-safe.c
+++ b/analyzer/test/regression/uva/test-30-safe.c
@@ -1,0 +1,9 @@
+#include <stdlib.h>
+int main() {
+  char* p = malloc(sizeof(char));
+  if (!p) {
+    return 5;
+  }
+  *p = 3;
+  return (int)*p;
+}

--- a/analyzer/test/regression/uva/test-31-error.cpp
+++ b/analyzer/test/regression/uva/test-31-error.cpp
@@ -1,0 +1,6 @@
+#include <memory>
+int main(int argc, char *argv[])
+{
+  bool* test1 = new bool;
+  return (int)*test1;
+}

--- a/analyzer/test/regression/uva/test-32-error.cpp
+++ b/analyzer/test/regression/uva/test-32-error.cpp
@@ -1,0 +1,13 @@
+#include <memory>
+
+bool* getBool()
+{
+  return new bool;
+}
+
+int main(int argc, char *argv[])
+{
+  bool* test1 = new bool;
+  bool* test2 = getBool();
+  return (int)(*test1 && *test2);
+}

--- a/analyzer/test/regression/uva/test-33-error.cpp
+++ b/analyzer/test/regression/uva/test-33-error.cpp
@@ -1,0 +1,6 @@
+#include <memory>
+int main(int argc, char *argv[])
+{
+  std::shared_ptr<bool> test1 (new bool);
+  return (int)*test1;
+}

--- a/analyzer/test/regression/uva/test-34-safe.cpp
+++ b/analyzer/test/regression/uva/test-34-safe.cpp
@@ -1,0 +1,8 @@
+#include <memory>
+using namespace std;
+int main(int argc, char *argv[])
+{
+  auto test1 = make_shared<bool>();
+  //dereference pointer that is properly initialized.
+  return (int)*test1;
+}

--- a/analyzer/test/regression/uva/test-35-safe.cpp
+++ b/analyzer/test/regression/uva/test-35-safe.cpp
@@ -1,0 +1,19 @@
+#include <memory>
+using namespace std;
+
+struct MyStruct {
+  int _aa;
+  int _bb;
+  MyStruct() noexcept
+  {
+    _aa = 5;
+    _bb = 7;
+  }
+};
+
+int main(int argc, char *argv[])
+{
+  auto test1 = make_shared<MyStruct>();
+  
+  return test1->_aa;
+}

--- a/analyzer/test/regression/uva/test-36-error.cpp
+++ b/analyzer/test/regression/uva/test-36-error.cpp
@@ -1,0 +1,18 @@
+#include <memory>
+using namespace std;
+
+struct MyStruct {
+  int _aa;
+  int _bb;
+  MyStruct() noexcept
+  {
+    //_aa = 5;
+    _bb = 7;
+  }
+};
+
+int main(int argc, char *argv[])
+{
+  auto test1 = make_shared<MyStruct>();
+  return test1->_aa;
+}

--- a/analyzer/test/regression/uva/test-37-error.cpp
+++ b/analyzer/test/regression/uva/test-37-error.cpp
@@ -1,0 +1,6 @@
+#include <memory>
+int main(int argc, char *argv[])
+{
+  std::unique_ptr<bool> test1 (new bool);
+  return (int)*test1;
+}

--- a/analyzer/test/regression/uva/test-38-safe.cpp
+++ b/analyzer/test/regression/uva/test-38-safe.cpp
@@ -1,0 +1,7 @@
+#include <memory>
+using namespace std;
+int main(int argc, char *argv[])
+{
+  auto test1 = make_unique<bool>();
+  return (int)*test1;
+}

--- a/analyzer/test/regression/uva/test-39-error.cpp
+++ b/analyzer/test/regression/uva/test-39-error.cpp
@@ -1,0 +1,16 @@
+struct MyStruct {
+  int _aa;
+  int _bb;
+  MyStruct() noexcept
+  {
+    //_aa = 5;
+    _bb = 7;
+  }
+};
+
+int main(int argc, char *argv[])
+{
+  MyStruct ss{};
+
+  return ss._aa;
+}

--- a/core/include/ikos/core/domain/memory/value.hpp
+++ b/core/include/ikos/core/domain/memory/value.hpp
@@ -62,7 +62,6 @@
 #include <ikos/core/semantic/machine_int/variable.hpp>
 #include <ikos/core/semantic/memory/value/cell_factory.hpp>
 #include <ikos/core/semantic/memory/value/cell_variable.hpp>
-#include <unordered_set>
 
 namespace ikos {
 namespace core {
@@ -1113,6 +1112,30 @@ private:
       if (cell == new_cell) {
         found = true;
       } else if (this->cell_overlap(cell, new_cell)) {
+        if (this->_scalar.uninit_is_uninitialized(cell)) {
+          // Make new uninitialized cells for the parts not covered
+          // by the new_cell.
+          IntInterval new_interval = this->cell_range(new_cell);
+          MachineInt new_lb = new_interval.lb();
+          MachineInt new_ub = new_interval.ub();
+          IntInterval un_interval = this->cell_range(cell);
+          MachineInt un_lb = un_interval.lb();
+          MachineInt un_ub = un_interval.ub();
+          if (un_lb < new_lb) {
+            MachineInt low_size = new_lb - un_lb;
+            VariableRef low_cell = this->make_cell(base, un_lb, low_size, sign);
+            this->_scalar.uninit_refine(low_cell, Uninitialized::uninitialized());
+            new_cells.add(low_cell);
+          }
+          if (new_ub < un_ub) {
+            MachineInt high_size = un_ub - new_ub;
+            auto one = MachineInt(1, high_size.bit_width(), Unsigned);
+            MachineInt high_lb = new_ub + one;
+            VariableRef high_cell = this->make_cell(base, high_lb, high_size, sign);
+            this->_scalar.uninit_refine(high_cell, Uninitialized::uninitialized());
+            new_cells.add(high_cell);
+          }
+        }
         this->_scalar.dynamic_forget(cell);
         new_cells.remove(cell);
       }
@@ -1165,57 +1188,50 @@ private:
   }
 
 
-  /// \brief Detect Read from Uninitialized Memory
-  bool is_read_uninitialized(MemoryLocationRef base,
+
+  /// \brief Detect whether the read bits are initialized, uninitialized,
+  /// for possibly uninitialized.
+  ikos::core::Uninitialized is_read_uninitialized(MemoryLocationRef base,
                             const MachineInt& offset,
                             const MachineInt& size) {
-    CellSetT cells = this->_cells.get(base);
-    if (cells.is_empty()) {
-      return true; // If no cells, certainly uninitialized.
-    }
-    if (!offset.fits<long>()) {
-      // Give up if we cannot manipulate the offset natively.
-      return false;
-    }
-    if (!size.fits<long>()) {
-      // Give up if we cannot manipulate the size natively.
-      return false;
+    if (!size.fits<uint32_t>()) {
+      // The ZNumber infrastructure cannot handle shifts by
+      // more than the max 32-bit number, so give up in that case.
+      // and assume possibly uninitialized.
+      return ikos::core::Uninitialized::top();
     }
 
-    // Our strategy is to define a set of byte offsets we are
-    // trying to read. Then remove from the set byte offsets
-    // covered by existing cells. If it becomes empty, then
-    // all bytes are initialized.
-    long loffset = offset.to<long>();
-    long lsize = size.to<long>();
-    std::unordered_set<long> bytes;
-    for (long i = 0; i < lsize; ++i) {
-      long byte_offset = loffset + i; // Worry about overflow?
-      bytes.insert(byte_offset);
-    }
+    // Use ZNumbers as bitvectors for bits [0,size) relative to the
+    // low bound of the read (i.e. offset).
+    ZNumber zoffset = offset.to_z_number();
+    ZNumber zsize = size.to_z_number();
+    ZNumber zupper = zoffset + zsize;
+    ZNumber read_mask = make_clipped_mask(zoffset, zsize, zoffset, zsize);
+
+    CellSetT cells = this->_cells.get(base);
+    ZNumber initialized_coverage = ZNumber(0);
+    ZNumber uninitialized_coverage = ZNumber(0);
     for (VariableRef cell : cells) {
-      const MachineInt& other_offset = CellVariableTrait::offset(cell);
-      const MachineInt& other_size = CellVariableTrait::size(cell);
-      if (!other_offset.fits<long>()) {
-        // Give up if we cannot manipulate the offset natively.
-        return false;
-      }
-      if (!other_size.fits<long>()) {
-        // Give up if we cannot manipulate the size natively.
-        return false;
-      }
-      long l_other_offset = other_offset.to<long>();
-      long l_other_size = other_size.to<long>();
-      long l_other_max = l_other_offset + l_other_size - 1;
-      for (long j = l_other_offset; j <= l_other_max ; ++j) {
-        bytes.erase(j);
-      }
-      if (bytes.empty()) {
-        // It was completely initialized.
-        return false;
+      const ZNumber& other_offset = CellVariableTrait::offset(cell).to_z_number();
+      const ZNumber& other_size = CellVariableTrait::size(cell).to_z_number();
+      ZNumber cell_mask =
+          make_clipped_mask(other_offset, other_size, zoffset, zsize);
+      Uninitialized cell_uninit = this->uninit_to_uninitialized(cell);
+      if (cell_uninit == ikos::core::Uninitialized::initialized()) {
+        initialized_coverage |= cell_mask;
+      } else if (cell_uninit == ikos::core::Uninitialized::uninitialized()) {
+        uninitialized_coverage |= cell_mask;
       }
     }
-    return true;
+    if (read_mask == initialized_coverage) {
+      // The read bits are completely initialized
+      return ikos::core::Uninitialized::initialized();
+    } else if (read_mask == uninitialized_coverage) {
+      // The read bits are all uninitialized
+      return ikos::core::Uninitialized::uninitialized();
+    }
+    // The bits may or may not be initialized, so top.
+    return ikos::core::Uninitialized::top();
   }
 
   /// \brief Create a new cell for a read
@@ -1223,12 +1239,63 @@ private:
                                        const MachineInt& offset,
                                        const MachineInt& size,
                                        Signedness sign) {
-    VariableRef new_cell = this->make_cell(base, offset, size, sign);
-    CellSetT cells = this->_cells.get(base);
-    cells.add(new_cell);
-    this->_cells.set(base, cells);
+    ikos::core::Uninitialized addr_uninit =
+        is_read_uninitialized(base, offset, size);
 
-    // TODO(marthaud): perform further reduction in case of partial overlaps
+    VariableRef new_cell = this->make_cell(base, offset, size, sign);
+    this->_scalar.uninit_refine(new_cell, addr_uninit);
+    CellSetT cells = this->_cells.get(base);
+
+    if (cells.is_empty()) {
+      // No cell found for the base address
+      this->_cells.set(base, CellSetT{new_cell});
+      return new_cell;
+    }
+
+    CellSetT new_cells = cells;
+    bool found = false;
+
+    IntInterval new_interval = this->cell_range(new_cell);
+    MachineInt new_lb = new_interval.lb();
+    MachineInt new_ub = new_interval.ub();
+
+    // Remove overlapping cells if uninitialized.
+    for (VariableRef cell : cells) {
+      if (cell == new_cell) {
+        found = true;
+      } else if (this->cell_overlap(cell, new_cell)) {
+        if (this->_scalar.uninit_is_uninitialized(cell)) {
+          // Make new uninitialized cells for the parts not covered
+          // by the new_cell.
+          IntInterval un_interval = this->cell_range(cell);
+          MachineInt un_lb = un_interval.lb();
+          MachineInt un_ub = un_interval.ub();
+          if (un_lb < new_lb) {
+            MachineInt low_size = new_lb - un_lb;
+            VariableRef low_cell = this->make_cell(base, un_lb, low_size, sign);
+            this->_scalar.uninit_refine(low_cell, Uninitialized::uninitialized());
+            new_cells.add(low_cell);
+          }
+          if (new_ub < un_ub) {
+            MachineInt high_size = un_ub - new_ub;
+            auto one = MachineInt(1, high_size.bit_width(), Unsigned);
+            MachineInt high_lb = new_ub + one;
+            VariableRef high_cell = this->make_cell(base, high_lb, high_size, sign);
+            this->_scalar.uninit_refine(high_cell, Uninitialized::uninitialized());
+            new_cells.add(high_cell);
+          }
+          this->_scalar.dynamic_forget(cell);
+          new_cells.remove(cell);
+        } else {
+          // Cell is at least potentially initialized, so keep it.
+        }
+      }
+    }
+
+    if (!found) {
+      new_cells.add(new_cell);
+    }
+    this->_cells.set(base, new_cells);
     return new_cell;
   }
 
@@ -1551,11 +1618,6 @@ public:
       bool first = true;
 
       for (MemoryLocationRef addr : addrs) {
-        if (is_read_uninitialized(addr, offset, size)) {
-          // No cell found for the base address, so must not be initialized.
-          this->uninit_refine(lhs.var(), Uninitialized::uninitialized());
-          return;
-        }
 
         VariableRef cell =
             this->read_realize_single_cell(addr, offset, size, sign);
@@ -1602,10 +1664,6 @@ public:
 
       this->_scalar.pointer_refine(lhs.var(), pointer_set);
     }
-
-    // Reading uninitialized memory is an error
-    // Therefore, the result of a read is always initialized
-    this->_scalar.uninit_assert_initialized(lhs.var());
   }
 
   void mem_copy(VariableRef dest,

--- a/core/include/ikos/core/domain/scalar/composite.hpp
+++ b/core/include/ikos/core/domain/scalar/composite.hpp
@@ -676,6 +676,19 @@ public:
     this->_integer.apply(op, x, y);
   }
 
+
+  // \brief Assert that x is initialized (throw if not), but only if the
+  // operation, op, is not logical "and" or "or" as these are used in
+  // bitfield operations which may start with uninitialized memory.
+  // Is only called if one of the operands is constant.
+  void assert_initialized_if_not_and_or(IntBinaryOperator op, VariableRef x) {
+    if ((op == IntBinaryOperator::And) || (op == IntBinaryOperator::Or)) {
+      return;
+    }
+
+    this->_uninitialized.assert_initialized(x);
+  }
+
   void int_apply(IntBinaryOperator op,
                  VariableRef x,
                  VariableRef y,
@@ -711,7 +724,7 @@ public:
       return;
     }
 
-    this->_uninitialized.assert_initialized(y);
+    this->assert_initialized_if_not_and_or(op, y);
 
     if (this->_uninitialized.is_bottom()) {
       this->set_to_bottom();
@@ -733,7 +746,7 @@ public:
       return;
     }
 
-    this->_uninitialized.assert_initialized(z);
+    this->assert_initialized_if_not_and_or(op, z);
 
     if (this->_uninitialized.is_bottom()) {
       this->set_to_bottom();

--- a/core/test/unit/number/z_number.cpp
+++ b/core/test/unit/number/z_number.cpp
@@ -606,4 +606,32 @@ BOOST_AUTO_TEST_CASE(test_z_number) {
   boost::test_tools::output_test_stream output;
   output << Z(42);
   BOOST_CHECK(output.is_equal("42"));
+
+// ZNumber single_mask(const ZNumber& size);
+
+  BOOST_CHECK(single_mask(Z(0)) == Z(0));
+  BOOST_CHECK(single_mask((Z(1) << 32) - 1) == single_mask((Z(1) << 32) - 1));
+  // On some platforms bigger values will work, but don't count on it.
+  // BOOST_CHECK(single_mask(Z(1) << 34) == single_mask(Z(1) << 34));
+  BOOST_CHECK(single_mask(Z(5)).str(2) == "11111");
+
+  //  ZNumber double_mask(const ZNumber& low, const ZNumber& high);
+  BOOST_CHECK(double_mask(Z(2), Z(5)).str(2) == "11100");
+  BOOST_CHECK(double_mask(Z(0), Z(5)).str(2) == "11111");
+
+
+  // ZNumber make_clipped_mask(
+  //      const ZNumber& low, const ZNumber& size,
+  //      const ZNumber& lower_clip, const ZNumber& size_clip);
+  BOOST_CHECK(make_clipped_mask(Z(2), Z(5), Z(2), Z(5)).str(2) == "11111");
+  BOOST_CHECK(make_clipped_mask(Z(0), Z(10), Z(2), Z(5)).str(2) == "11111");
+  BOOST_CHECK(make_clipped_mask(Z(0), Z(7), Z(2), Z(5)).str(2) == "11111");
+  BOOST_CHECK(make_clipped_mask(Z(0), Z(5), Z(2), Z(5)).str(2) == "111");
+  BOOST_CHECK(make_clipped_mask(Z(0), Z(2), Z(2), Z(5)).str(2) == "0");
+  BOOST_CHECK(make_clipped_mask(Z(0), Z(1), Z(2), Z(5)).str(2) == "0");
+  BOOST_CHECK(make_clipped_mask(Z(3), Z(2), Z(2), Z(5)).str(2) == "110");
+  BOOST_CHECK(make_clipped_mask(Z(2), Z(4), Z(2), Z(5)).str(2) == "1111");
+  BOOST_CHECK(make_clipped_mask(Z(2), Z(5), Z(2), Z(5)).str(2) == "11111");
+  BOOST_CHECK(make_clipped_mask(Z(6), Z(2), Z(2), Z(5)).str(2) == "10000");
+  BOOST_CHECK(make_clipped_mask(Z(7), Z(5), Z(2), Z(5)).str(2) == "0");
 }

--- a/frontend/llvm/src/ikos_import.cpp
+++ b/frontend/llvm/src/ikos_import.cpp
@@ -183,9 +183,10 @@ int main(int argc, char** argv) {
 
     // Check for debug information
     if (!llvm_to_ar::has_debug_info(*module)) {
+      // Warn but allow to proceed.
       llvm::errs() << progname << ": " << InputFilename
-                   << ": error: input module has no debug information\n";
-      return 3;
+                   << ": warning: input module has no debug information\n";
+      llvm::errs() << "... Output may be less user friendly.\n";
     }
 
     // AR context

--- a/frontend/llvm/src/import/bundle.cpp
+++ b/frontend/llvm/src/import/bundle.cpp
@@ -43,6 +43,7 @@
  *
  ******************************************************************************/
 
+#include <iostream>
 #include <ikos/core/support/assert.hpp>
 
 #include <ikos/ar/semantic/statement.hpp>
@@ -71,7 +72,7 @@ ar::GlobalVariable* BundleImporter::translate_global_variable(
 
   std::string name;
   if (gv->hasName()) {
-    name = gv->getName();
+    name = gv->getName().str();
   } else {
     name = this->_bundle->find_available_name("__unnamed_global_var");
   }
@@ -178,10 +179,7 @@ ar::Function* BundleImporter::translate_function(llvm::Function* fun) {
     ar_fun = this->translate_clang_generated_function(fun);
   } else {
     // No debug information on internal function
-    std::ostringstream buf;
-    buf << "missing debug information for llvm function "
-        << fun->getName().str();
-    throw ImportError(buf.str());
+    ar_fun = this->translate_internal_function(fun);
   }
 
   if (ar_fun != nullptr) {
@@ -254,6 +252,27 @@ ar::Function* BundleImporter::translate_extern_function(llvm::Function* fun) {
                                   fun->getName().str(),
                                   /*is_definition = */ false);
   }
+
+  ikos_assert(ar_fun);
+  return ar_fun;
+}
+
+// This is used in the case where there is no debug information.
+ar::Function* BundleImporter::translate_internal_function(llvm::Function* fun) {
+  ikos_assert(!fun->isDeclaration());
+
+  ar::Function* ar_fun = nullptr;
+
+  // Use int for the type since it is more common than unsigned in C
+  llvm::FunctionType* type = fun->getFunctionType();
+
+  auto ar_type = ar::cast< ar::FunctionType >(
+      _ctx.type_imp->translate_type(type, ar::Signed));
+
+  ar_fun = ar::Function::create(this->_bundle,
+				ar_type,
+				fun->getName().str(),
+				/*is_definition = */ true);
 
   ikos_assert(ar_fun);
   return ar_fun;
@@ -335,8 +354,13 @@ ar::Function* BundleImporter::translate_library_function(llvm::Function* fun) {
       buf << "llvm function " << fun->getName().str() << " and ar intrinsic "
           << ar_fun->name() << " have a different type";
     }
-
-    throw ImportError(buf.str());
+    // We no longer throw but give warning.
+    //   throw ImportError(buf.str());
+    std::cerr << "Warning:" << buf.str() << "\n";
+    std::cerr << "LLVM function declaration\n";
+    std::cerr << "ikos ar expected function declaration\n";
+    std::cerr << "Expected signature will be ignored.\n";
+    ar_fun = nullptr;
   }
 
   return ar_fun;

--- a/frontend/llvm/src/import/bundle.hpp
+++ b/frontend/llvm/src/import/bundle.hpp
@@ -118,6 +118,11 @@ private:
   /// llvm.dbg.* functions)
   ar::Function* translate_extern_function(llvm::Function*);
 
+  /// \brief Translate an internal llvm::Function* into an ar::Function*
+  ///
+  /// This is used when no debug information is available.
+  ar::Function* translate_internal_function(llvm::Function*);
+
 public:
   /// \brief Return true if the given intrinsic should not be translated
   bool ignore_intrinsic(llvm::Intrinsic::ID);

--- a/frontend/llvm/src/import/importer.cpp
+++ b/frontend/llvm/src/import/importer.cpp
@@ -73,9 +73,6 @@ bool has_debug_info(llvm::Module& m) {
 // Importer
 
 ar::Bundle* Importer::import(llvm::Module& module, ImportOptions opts) {
-  // We now support analysis with no debug information, so do not assert.
-  //    ikos_assert_msg(has_debug_info(module), "no debug information");
-
   // Create the data layout
   std::unique_ptr< ar::DataLayout > data_layout =
       translate_data_layout(module.getDataLayout(), module.getContext());

--- a/frontend/llvm/src/import/importer.cpp
+++ b/frontend/llvm/src/import/importer.cpp
@@ -73,7 +73,8 @@ bool has_debug_info(llvm::Module& m) {
 // Importer
 
 ar::Bundle* Importer::import(llvm::Module& module, ImportOptions opts) {
-  ikos_assert_msg(has_debug_info(module), "no debug information");
+  // We now support analysis with no debug information, so do not assert.
+  //    ikos_assert_msg(has_debug_info(module), "no debug information");
 
   // Create the data layout
   std::unique_ptr< ar::DataLayout > data_layout =


### PR DESCRIPTION
1. Fix a problem in the tracking of the values of
dynamically-allocated memory so that use of
uninitialized dynamically-allocated memory is
detected.

2. Allow analysis of programs without debug information.
This is important for the case where the LLVM
comes from a binary lifter where no debug information
may be available. Without debug information the name
of the function with a problem is reported but
file and line number information is not available.