### PR TITLE
Add tracing of invariants, triples optional

### DIFF
--- a/analyzer/include/ikos/analyzer/analysis/option.hpp
+++ b/analyzer/include/ikos/analyzer/analysis/option.hpp
@@ -335,6 +335,9 @@ public:
   /// \brief Wether we should perform checks or not
   bool use_checks;
 
+  /// \brief Whether to trace states during analysis
+  bool trace_ar_statements;
+
   /// \brief Policy of initialization for global variables
   GlobalsInitPolicy globals_init_policy;
 

--- a/analyzer/include/ikos/analyzer/analysis/value/interprocedural/sequential/function_fixpoint.hpp
+++ b/analyzer/include/ikos/analyzer/analysis/value/interprocedural/sequential/function_fixpoint.hpp
@@ -43,6 +43,7 @@
 
 #pragma once
 
+#include "ikos/ar/format/namer.hpp"
 #include <ikos/ar/semantic/code.hpp>
 #include <ikos/ar/semantic/function.hpp>
 
@@ -100,6 +101,8 @@ private:
 
   /// \brief Progress logger
   ProgressLogger& _logger;
+
+  std::unique_ptr<ar::Namer> _namer;
 
 public:
   /// \brief Constructor for an entry point

--- a/analyzer/include/ikos/analyzer/analysis/value/interprocedural/sequential/function_fixpoint.hpp
+++ b/analyzer/include/ikos/analyzer/analysis/value/interprocedural/sequential/function_fixpoint.hpp
@@ -123,6 +123,8 @@ public:
                    ar::CallBase* call,
                    ar::Function* callee);
 
+  virtual ~FunctionFixpoint();
+  
   /// \brief Compute the fixpoint
   void run(AbstractDomain inv) override;
 

--- a/analyzer/python/ikos/analyzer.py
+++ b/analyzer/python/ikos/analyzer.py
@@ -345,6 +345,11 @@ def parse_arguments(argv):
                        help='Display the Abstract Representation as text',
                        action='store_true',
                        default=False)
+    debug.add_argument('--trace-ar-stmts',
+                       dest='trace_ar_stmts',
+                       help='Trace analysis of ar statements',
+                       action='store_true',
+                       default=False)
     debug.add_argument('--display-liveness',
                        dest='display_liveness',
                        help='Display liveness analysis results',
@@ -843,6 +848,8 @@ def ikos_analyzer(db_path, pp_path, opt):
 
     if opt.display_ar:
         cmd.append('-display-ar')
+    if opt.trace_ar_stmts:
+        cmd.append('-trace-ar-stmts')
     if opt.display_liveness:
         cmd.append('-display-liveness')
     if opt.display_function_pointer:

--- a/analyzer/src/analysis/option.cpp
+++ b/analyzer/src/analysis/option.cpp
@@ -113,6 +113,8 @@ void AnalysisOptions::save(SettingsTable& table) {
 
   table.insert("use-checks", this->use_checks);
 
+  table.insert("trace-ar-statements", this->trace_ar_statements);
+
   table.insert("globals-init-policy",
                globals_init_policy_str(this->globals_init_policy));
 

--- a/analyzer/src/analysis/value/interprocedural/sequential/function_fixpoint.cpp
+++ b/analyzer/src/analysis/value/interprocedural/sequential/function_fixpoint.cpp
@@ -78,9 +78,11 @@ FunctionFixpoint::FunctionFixpoint(
       _exit_invariant(make_bottom_abstract_value(ctx)),
       _return_stmt(nullptr),
       _logger(logger),
-      _namer(new ar::Namer(entry_point->body()))
+      _namer()
 {
   if (_ctx.opts.trace_ar_statements) {
+    this->_namer =
+        std::unique_ptr<ar::Namer>(new ar::Namer(entry_point->body()));
     auto msg = analyzer::log::msg();
     auto& stream = msg.stream();
     msg << "\n>>>>>>>>>>>>>>\nEntering Interprocedural Sequential FunctionFixpoint for ";
@@ -103,9 +105,11 @@ FunctionFixpoint::FunctionFixpoint(Context& ctx,
       _exit_invariant(make_bottom_abstract_value(ctx)),
       _return_stmt(nullptr),
       _logger(caller._logger),
-      _namer(new ar::Namer(callee->body()))
+      _namer()
 {
   if (_ctx.opts.trace_ar_statements) {
+    this->_namer =
+        std::unique_ptr<ar::Namer>(new ar::Namer(callee->body()));
     ar::TextFormatter formatter{};
     auto msg = analyzer::log::msg();
     auto& stream = msg.stream();

--- a/analyzer/src/analysis/value/interprocedural/sequential/function_fixpoint.cpp
+++ b/analyzer/src/analysis/value/interprocedural/sequential/function_fixpoint.cpp
@@ -77,14 +77,14 @@ FunctionFixpoint::FunctionFixpoint(
       _checkers(checkers),
       _exit_invariant(make_bottom_abstract_value(ctx)),
       _return_stmt(nullptr),
-      _logger(logger)
+      _logger(logger),
+      _namer(new ar::Namer(entry_point->body()))
 {
   if (_ctx.opts.trace_ar_statements) {
-    ar::TextFormatter formatter{};
-    auto& stream = analyzer::log::msg().stream();
-    stream << "\n>>>>>>>>>>>>>>\nEntering Interprocedural Sequential FunctionFixpoint for ";
-    ar::Namer namer;
-    formatter.format_header(stream, _function, namer);
+    auto msg = analyzer::log::msg();
+    auto& stream = msg.stream();
+    msg << "\n>>>>>>>>>>>>>>\nEntering Interprocedural Sequential FunctionFixpoint for ";
+    ar::TextFormatter().format_header(stream, _function, *_namer);
     stream << std::endl;
   }
 }
@@ -102,17 +102,18 @@ FunctionFixpoint::FunctionFixpoint(Context& ctx,
       _checkers(caller._checkers),
       _exit_invariant(make_bottom_abstract_value(ctx)),
       _return_stmt(nullptr),
-      _logger(caller._logger)
+      _logger(caller._logger),
+      _namer(new ar::Namer(callee->body()))
 {
   if (_ctx.opts.trace_ar_statements) {
     ar::TextFormatter formatter{};
-    auto& stream = analyzer::log::msg().stream();
-    stream << "\n>>>>>>>>>>>>>>\nEntering Interprocedural Sequential FunctionFixpoint for ";
-    ar::Namer namer;
-    formatter.format_header(stream, _function, namer);
-    stream << "\n  from caller ";
-    formatter.format_header(stream, caller._function, namer);
-    stream << "\n  from call site ";
+    auto msg = analyzer::log::msg();
+    auto& stream = msg.stream();
+    msg << "\n>>>>>>>>>>>>>>\nEntering Interprocedural Sequential FunctionFixpoint for ";
+    formatter.format_header(stream, _function, *_namer);
+    msg << "\n  from caller ";
+    formatter.format_header(stream, caller._function, *_namer);
+    msg << "\n  from call site ";
     call->dump(stream);
     stream << std::endl;
   }
@@ -120,11 +121,10 @@ FunctionFixpoint::FunctionFixpoint(Context& ctx,
 
 FunctionFixpoint::~FunctionFixpoint() noexcept {
   if (_ctx.opts.trace_ar_statements) {
-    ar::TextFormatter formatter{};
-    auto& stream = analyzer::log::msg().stream();
-    stream << "\n<<<<<<<<<<\nExiting Interprocedural Sequential FunctionFixpoint for ";
-    ar::Namer namer;
-    formatter.format_header(stream, _function, namer);
+    auto msg = analyzer::log::msg();
+    auto& stream = msg.stream();
+    msg << "\n<<<<<<<<<<\nExiting Interprocedural Sequential FunctionFixpoint for ";
+    ar::TextFormatter().format_header(stream, _function, *_namer);
     stream << std::endl;
   }
 }
@@ -240,26 +240,30 @@ AbstractDomain FunctionFixpoint::analyze_node(ar::BasicBlock* bb,
                                               this->_callees_cache);
   exec_engine.exec_enter(bb);
   if (_ctx.opts.trace_ar_statements) {
-    auto& stream = analyzer::log::msg().stream();
-    stream << "Entering basic block: ";
+    auto msg = analyzer::log::msg();
+    auto& stream = msg.stream();
+    msg << "Entering basic block: ";
     bb->dump(stream);
     stream << std::endl;
-    stream << "  Invariant on entry to basic block:" << std::endl;
+    msg << "  Invariant on entry to basic block:";
+    stream << std::endl;
     exec_engine.inv().dump(stream);
     stream << std::endl;
   }
 
   for (ar::Statement* stmt : *bb) {
     if (_ctx.opts.trace_ar_statements) {
-      auto& stream = analyzer::log::msg().stream();
-      stream << "Processing: ";
+      auto msg = analyzer::log::msg();
+      auto& stream = msg.stream();
+      msg << "Processing: ";
       stmt->dump(stream);
       stream << std::endl;
     }
     transfer_function(exec_engine, call_exec_engine, stmt);
     if (_ctx.opts.trace_ar_statements) {
-      auto& stream = analyzer::log::msg().stream();
-      stream << "  Invariant after: ";
+      auto msg = analyzer::log::msg();
+      auto& stream = msg.stream();
+      msg << "  Invariant after: ";
       exec_engine.inv().dump(stream);
       stream << std::endl;
     }
@@ -348,19 +352,22 @@ void FunctionFixpoint::run_checks() {
     exec_engine.exec_enter(bb);
 
     if (_ctx.opts.trace_ar_statements) {
-      auto& stream = analyzer::log::msg().stream();
-      stream << "Entering basic block in run_checks: ";
+      auto msg = analyzer::log::msg();
+      auto& stream = msg.stream();
+      msg << "Entering basic block in run_checks: ";
       bb->dump(stream);
       stream << std::endl;
-      stream << "  Invariant on entry to basic block:" << std::endl;
+      msg << "  Invariant on entry to basic block:";
+      stream << std::endl;
       exec_engine.inv().dump(stream);
       stream << std::endl;
     }
 
     for (ar::Statement* stmt : *bb) {
       if (_ctx.opts.trace_ar_statements) {
-        auto& stream = analyzer::log::msg().stream();
-        stream << "Checking: ";
+        auto msg = analyzer::log::msg();
+        auto& stream = msg.stream();
+        msg << "Checking: ";
         stmt->dump(stream);
         stream << std::endl;
       }
@@ -377,8 +384,9 @@ void FunctionFixpoint::run_checks() {
       transfer_function(exec_engine, call_exec_engine, stmt);
 
       if (_ctx.opts.trace_ar_statements) {
-        auto& stream = analyzer::log::msg().stream();
-        stream << "  In run_checks, invariant after: ";
+        auto msg = analyzer::log::msg();
+        auto& stream = msg.stream();
+        msg << "  In run_checks, invariant after: ";
         exec_engine.inv().dump(stream);
         stream << std::endl;
       }

--- a/analyzer/src/analysis/value/interprocedural/sequential/function_fixpoint.cpp
+++ b/analyzer/src/analysis/value/interprocedural/sequential/function_fixpoint.cpp
@@ -81,8 +81,7 @@ FunctionFixpoint::FunctionFixpoint(
       _namer()
 {
   if (_ctx.opts.trace_ar_statements) {
-    this->_namer =
-        std::unique_ptr<ar::Namer>(new ar::Namer(entry_point->body()));
+    this->_namer = std::make_unique<ar::Namer>(entry_point->body());
     auto msg = analyzer::log::msg();
     auto& stream = msg.stream();
     msg << "\n>>>>>>>>>>>>>>\nEntering Interprocedural Sequential FunctionFixpoint for ";
@@ -108,8 +107,7 @@ FunctionFixpoint::FunctionFixpoint(Context& ctx,
       _namer()
 {
   if (_ctx.opts.trace_ar_statements) {
-    this->_namer =
-        std::unique_ptr<ar::Namer>(new ar::Namer(callee->body()));
+    this->_namer = std::make_unique<ar::Namer>(callee->body());
     ar::TextFormatter formatter{};
     auto msg = analyzer::log::msg();
     auto& stream = msg.stream();

--- a/analyzer/src/ikos_analyzer.cpp
+++ b/analyzer/src/ikos_analyzer.cpp
@@ -581,6 +581,11 @@ static llvm::cl::opt< bool > DisplayAR(
     llvm::cl::desc("Display the Abstract Representation as text"),
     llvm::cl::cat(DebugCategory));
 
+static llvm::cl::opt< bool > TraceARStmts(
+    "trace-ar-stmts",
+    llvm::cl::desc("Trace Abstract Representation statements during analysis"),
+    llvm::cl::cat(DebugCategory));
+
 static llvm::cl::opt< bool > GenerateDot(
     "generate-dot",
     llvm::cl::desc("Generate a .dot file for each function"),
@@ -807,6 +812,7 @@ static analyzer::AnalysisOptions make_analysis_options(ar::Bundle* bundle) {
       .use_partitioning_domain = EnablePartitioningDomain,
       .use_fixpoint_cache = !NoFixpointCache,
       .use_checks = !NoChecks,
+      .trace_ar_statements = TraceARStmts,
       .globals_init_policy = GlobalsInitPolicy,
       .progress = Progress,
       .display_invariants = DisplayInvariants,

--- a/ar/include/ikos/ar/format/text.hpp
+++ b/ar/include/ikos/ar/format/text.hpp
@@ -85,6 +85,9 @@ public:
   /// \brief Format a global variable into text format
   void format(std::ostream&, GlobalVariable*) const;
 
+  // \brief Format just the head part of a function.
+  void format_header(std::ostream& o, const Function* f, Namer& namer) const;
+
   /// \brief Format a function into text format
   void format(std::ostream&, Function*) const;
 

--- a/ar/include/ikos/ar/format/text.hpp
+++ b/ar/include/ikos/ar/format/text.hpp
@@ -86,7 +86,7 @@ public:
   void format(std::ostream&, GlobalVariable*) const;
 
   // \brief Format just the head part of a function.
-  void format_header(std::ostream& o, const Function* f, Namer& namer) const;
+  void format_header(std::ostream&, const Function*, Namer&) const;
 
   /// \brief Format a function into text format
   void format(std::ostream&, Function*) const;

--- a/ar/src/format/text.cpp
+++ b/ar/src/format/text.cpp
@@ -188,47 +188,8 @@ void TextFormatter::format_header(std::ostream& o, const Function* f,
 }
 
 void TextFormatter::format(std::ostream& o, Function* f) const {
-  FunctionType* type = f->type();
   Namer namer;
-
-  // declare/define
-  if (f->is_declaration()) {
-    o << "declare ";
-  } else {
-    namer.init(f->body()); // initialize the namer
-    o << "define ";
-  }
-
-  // return type and name
-  this->format(o, type->return_type());
-  o << " @" << f->name();
-
-  // parameters
-  o << "(";
-  if (f->is_declaration()) {
-    for (auto it = type->param_begin(), et = type->param_end(); it != et;) {
-      this->format(o, *it);
-      ++it;
-      if (it != et) {
-        o << ", ";
-      }
-    }
-  } else {
-    for (auto it = f->param_begin(), et = f->param_end(); it != et;) {
-      this->format(o, *it, namer, true);
-      ++it;
-      if (it != et) {
-        o << ", ";
-      }
-    }
-  }
-  if (f->is_var_arg()) {
-    if (type->num_parameters() > 0) {
-      o << ", ";
-    }
-    o << "...";
-  }
-  o << ")";
+  this->format_header(o, f, namer);
 
   // body
   if (f->is_declaration()) {

--- a/ar/src/semantic/bundle.cpp
+++ b/ar/src/semantic/bundle.cpp
@@ -41,7 +41,6 @@
  *
  ******************************************************************************/
 
-#include <iostream>
 #include <ikos/ar/semantic/bundle.hpp>
 #include <ikos/ar/semantic/code.hpp>
 #include <ikos/ar/semantic/context.hpp>
@@ -49,7 +48,6 @@
 #include <ikos/ar/semantic/function.hpp>
 #include <ikos/ar/semantic/value.hpp>
 #include <ikos/ar/support/assert.hpp>
-#include <ikos/ar/format/text.hpp>
 
 #include "context_impl.hpp"
 
@@ -62,8 +60,6 @@ Bundle::Bundle(Context& ctx,
     : _context(ctx),
       _data_layout(std::move(data_layout)),
       _target_triple(std::move(triple)) {
-  // According to the LLVM reference manual the target triple is optional.
-  // ikos_assert_msg(!this->_target_triple.empty(), "empty target triple");
 }
 
 Bundle::~Bundle() = default;

--- a/ar/src/semantic/bundle.cpp
+++ b/ar/src/semantic/bundle.cpp
@@ -41,6 +41,7 @@
  *
  ******************************************************************************/
 
+#include <iostream>
 #include <ikos/ar/semantic/bundle.hpp>
 #include <ikos/ar/semantic/code.hpp>
 #include <ikos/ar/semantic/context.hpp>
@@ -48,6 +49,7 @@
 #include <ikos/ar/semantic/function.hpp>
 #include <ikos/ar/semantic/value.hpp>
 #include <ikos/ar/support/assert.hpp>
+#include <ikos/ar/format/text.hpp>
 
 #include "context_impl.hpp"
 
@@ -60,7 +62,8 @@ Bundle::Bundle(Context& ctx,
     : _context(ctx),
       _data_layout(std::move(data_layout)),
       _target_triple(std::move(triple)) {
-  ikos_assert_msg(!this->_target_triple.empty(), "empty target triple");
+  // According to the LLVM reference manual the target triple is optional.
+  // ikos_assert_msg(!this->_target_triple.empty(), "empty target triple");
 }
 
 Bundle::~Bundle() = default;


### PR DESCRIPTION
1. Adds option to trace the invariant during analysis.

The ikos python script option is "--trace-ar-stmts".
The ikos-analyzer option is "-trace-ar-stmts".

2. According to the LLVM reference manual, the target
triple is optional. So no longer fail is it is not present.