### PR TITLE
Only ignore build and install directories in the repo root.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-build
-install
+/build/
+/install/
 
 # Editors
 *.swp


### PR DESCRIPTION
I believe the intent for these ignore entries is to prevent unintentional commits of the CMake `build` and `install` directories.

Without this patch the ignore pattern will match files called `build` and `install` as well as directories.

The prefix `/` also prevents the pattern from matching subdirectories which I believe to be unintentional false positives such as `doc/install`.