### PR TITLE
Add installation instructions for Ubuntu 22.04

### DIFF
--- a/doc/install/3.0/UBUNTU_22.04.md
+++ b/doc/install/3.0/UBUNTU_22.04.md
@@ -1,0 +1,32 @@
+Install IKOS dependencies on Ubuntu 20.04
+=========================================
+
+**NOTE: These instructions are for IKOS 3.0 with LLVM 9 and are not actively maintained. Please see the main [README.md](../../../README.md)**
+
+Here are the steps to install the required dependencies of IKOS on **[Ubuntu 20.04 LTS (Focal Fossa)](http://releases.ubuntu.com/20.04/)**.
+
+First, make sure your system is up-to-date: 
+
+```
+$ sudo apt-get update
+$ sudo apt-get upgrade
+```
+
+Then, run the following commands:
+
+```
+$ sudo apt-get install gcc g++ cmake libgmp-dev libboost-dev libboost-filesystem-dev \
+    libboost-thread-dev libboost-test-dev python3 python3-pygments libsqlite3-dev libtbb-dev \
+    libz-dev libedit-dev llvm-9 llvm-9-dev llvm-9-tools clang-9
+```
+
+When running cmake to build IKOS, you will need to define `LLVM_CONFIG_EXECUTABLE`:
+
+```
+$ cmake \
+    -DCMAKE_INSTALL_PREFIX="/path/to/ikos-install-directory" \
+    -DLLVM_CONFIG_EXECUTABLE="/usr/bin/llvm-config-9" \
+    ..
+```
+
+You are now ready to build IKOS. Go to the section [Build and Install](../../../README.md#build-and-install) in README.md

--- a/doc/install/3.0/UBUNTU_22.04.md
+++ b/doc/install/3.0/UBUNTU_22.04.md
@@ -1,9 +1,8 @@
-Install IKOS dependencies on Ubuntu 20.04
+Install IKOS dependencies on Ubuntu 22.04
 =========================================
 
-**NOTE: These instructions are for IKOS 3.0 with LLVM 9 and are not actively maintained. Please see the main [README.md](../../../README.md)**
 
-Here are the steps to install the required dependencies of IKOS on **[Ubuntu 20.04 LTS (Focal Fossa)](http://releases.ubuntu.com/20.04/)**.
+Here are the steps to install the required dependencies of IKOS on **[Ubuntu 22.04 LTS (Jammy Jellyfish)](http://releases.ubuntu.com/22.04/)**.
 
 First, make sure your system is up-to-date: 
 
@@ -17,7 +16,7 @@ Then, run the following commands:
 ```
 $ sudo apt-get install gcc g++ cmake libgmp-dev libboost-dev libboost-filesystem-dev \
     libboost-thread-dev libboost-test-dev python3 python3-pygments libsqlite3-dev libtbb-dev \
-    libz-dev libedit-dev llvm-9 llvm-9-dev llvm-9-tools clang-9
+    2ibz-dev libedit-dev llvm-14 llvm-14-dev llvm-14-tools clang-14
 ```
 
 When running cmake to build IKOS, you will need to define `LLVM_CONFIG_EXECUTABLE`:
@@ -25,7 +24,7 @@ When running cmake to build IKOS, you will need to define `LLVM_CONFIG_EXECUTABL
 ```
 $ cmake \
     -DCMAKE_INSTALL_PREFIX="/path/to/ikos-install-directory" \
-    -DLLVM_CONFIG_EXECUTABLE="/usr/bin/llvm-config-9" \
+    -DLLVM_CONFIG_EXECUTABLE="/usr/bin/llvm-config-14" \
     ..
 ```
 


### PR DESCRIPTION
This is a preliminary draft as ikos is not currently building on Ubuntu 22.04. (#193)

This set of instructions is sufficient to allow CMake to configure so we're on the right track.

My plan is to submit individual patches for the items blocking Ubuntu 22.04 builds and remove the Draft status from this PR once they have all been addressed.