### PR TITLE
Update arch instructions.

### DIFF
--- a/doc/install/3.0/ARCHLINUX.md
+++ b/doc/install/3.0/ARCHLINUX.md
@@ -1,7 +1,7 @@
 Install IKOS on Arch Linux
 ==========================
 
-**NOTE: These instructions are for IKOS 3.0 with LLVM 9 and are not actively maintained. Please see the main [README.md](../../../README.md)**
+**NOTE: These instructions are for IKOS 3.x with LLVM 14 and are not actively maintained. Please see the main [README.md](../../../README.md)**
 
 Here are the steps to install IKOS on **[Arch Linux](https://www.archlinux.org/)** using **[AUR](https://aur.archlinux.org/)** (Arch User Repository).
 

--- a/doc/install/3.0/ARCHLINUX.md
+++ b/doc/install/3.0/ARCHLINUX.md
@@ -11,10 +11,12 @@ First, make sure your system is up-to-date:
 $ sudo pacman -Syu
 ```
 
-Then, install the *apron* and *ikos* **[AUR](https://aur.archlinux.org/)** packages. See **[Installing packages](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages)** for detailed instructions.
+Then, install the IKOS dependency apron *apron*, and either the *ikos* package containing a recent IKOS release or the *ikos-git* package to build the latest development version of IKOS from the **[AUR](https://aur.archlinux.org/)**. See **[Installing packages](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages)** for detailed instructions.
+
+If the [*ikos* AUR package](https://aur.archlinux.org/packages/ikos) is out of date, you can flag it to notify the maintainer.
 
 * https://aur.archlinux.org/packages/apron
-* https://aur.archlinux.org/packages/ikos
+* https://aur.archlinux.org/packages/ikos or https://aur.archlinux.org/packages/ikos-git
 
 To be informed on updates by email, click on "Enable notifications" in "Package actions" on the AUR website.
 

--- a/doc/install/3.0/ARCHLINUX.md
+++ b/doc/install/3.0/ARCHLINUX.md
@@ -39,8 +39,8 @@ Now, install the following packages using **pacman**:
 $ sudo pacman -S base-devel cmake gmp boost boost-libs python python-pygments sqlite intel-tbb llvm llvm-libs clang
 ```
 
-Then, install the *apron-ppl-svn* **[AUR](https://aur.archlinux.org/)** package:
+Then, install the *apron-git* **[AUR](https://aur.archlinux.org/)** package:
 
-* https://aur.archlinux.org/packages/apron-ppl-svn
+* https://aur.archlinux.org/packages/apron-git
 
 You are now ready to build IKOS. Go to the section [Build and Install](../../../README.md#build-and-install) in README.md


### PR DESCRIPTION
I've just adopted the AUR packages for [ikos](https://aur.archlinux.org/packages/ikos) and [ikos-git](https://aur.archlinux.org/packages/ikos-git). I haven't gotten them building yet as I'm build issues which I'm too tired to trace just now.

Hopefully while working on Ubuntu 22.04 support I can also update the Arch instructions.