### PR TITLE
[analyzer] Handle formatting path in drive different from cwd (#165).

### DIFF
--- a/analyzer/python/ikos/report.py
+++ b/analyzer/python/ikos/report.py
@@ -295,8 +295,16 @@ def format_path(path):
         return None
 
     abs_path = os.path.realpath(path)
-    rel_path = os.path.relpath(os.path.realpath(path), os.getcwd())
-    return min(abs_path, rel_path, key=len)
+
+    # Check the drives to make sure a relpath can be obtained
+    path_drive_split = os.path.splitdrive(abs_path)
+    cur_drive_split  = os.path.splitdrive(os.getcwd())
+
+    if path_drive_split and (path_drive_split[0] != cur_drive_split[0]):
+        return abs_path
+    else:
+        rel_path = os.path.relpath(os.path.realpath(path), os.getcwd())
+        return min(abs_path, rel_path, key=len)
 
 
 def format_status(status):


### PR DESCRIPTION
The report-view command throws an exception when executed in Windows from a path in a drive different from that of the files being analyzed.

This is due to the use of `os.path.relpath` on two paths in potentially different drives as part of the definition of `format_path`. According to `relpath`'s definition, the function throws a `ValueError` on Windows if the two arguments provided are on different drives.

This PR modifies `format_path` so that it first checks if the paths are on different drives, returning the absolute path in that case, and executing the old behavior otherwise.