### PR TITLE
Address overreach of `.gitignore` rules wrt. `build`, `install`. Close #217.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-build
-install
+build/
+install/
 
 # Editors
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/
 install/
+!doc/install/
 
 # Editors
 *.swp


### PR DESCRIPTION
The .gitignore rules are matching build and install filenames and directories outside of the root of the tree. They also cause files under `doc/install` to be ignored, which is not desirable.

This PR adjusts the rules to match `build` and `install` only as directories, and to whitelist `doc/install` since that's supposed to contain documentation and not `cmake` by-products.