### PR TITLE
[analyzer] Use IPv6 when available. Close #158.

### DIFF
--- a/analyzer/python/ikos/scan.py
+++ b/analyzer/python/ikos/scan.py
@@ -641,8 +641,8 @@ class ScanServer(threading.Thread):
             try:
                 # try to start the http server on a random port
                 self.port = random.randint(8000, 9000)
-                self.httpd = http.HTTPServer(('', self.port),
-                                             ScanServerRequestHandler)
+                self.httpd = http.HTTPServerIPv6(('', self.port),
+                                                 ScanServerRequestHandler)
             except (OSError, IOError):
                 self.port = None  # port already in use
 

--- a/analyzer/python/ikos/view.py
+++ b/analyzer/python/ikos/view.py
@@ -62,7 +62,7 @@ from ikos import report
 from ikos import settings
 from ikos.enums import Result, CheckKind
 from ikos.highlight import CppLexer, HtmlFormatter, highlight
-from ikos.http import HTTPServer, BaseHTTPRequestHandler
+from ikos.http import HTTPServerIPv6, BaseHTTPRequestHandler
 from ikos.log import printf
 from ikos.output_db import OutputDatabase
 
@@ -337,7 +337,7 @@ class View:
         self.report = ViewReport(self.db)
 
         try:
-            self.httpd = HTTPServer(('', self.port), RequestHandler)
+            self.httpd = HTTPServerIPv6(('', self.port), RequestHandler)
         except (OSError, IOError) as e:
             log.error("Could not start the HTTP server: %s" % e)
             sys.exit(1)


### PR DESCRIPTION
This PR makes IKOS use IPv6 if it is available, as well as IPv4.