### PR TITLE
[analyzer] Skip llvm-objdump lines by format, not count

### DIFF
--- a/analyzer/python/ikos/scan.py
+++ b/analyzer/python/ikos/scan.py
@@ -571,7 +571,9 @@ def extract_bitcode(exe_path, bc_path):
     output = check_output(cmd)
     section_content = b''
 
-    for line in itertools.islice(output.splitlines(), 4, None):
+    for line in output.splitlines():
+        if not line.startswith(b' '):
+            continue
         n = line.find(b' ', 1)
         line = line[n + 1:n + 36]
         for item in line.split(b' '):


### PR DESCRIPTION
On my FreeBSD box, llvm-objdump14 outputs 3 extra lines, not 4. This has resulted in a chopped off beginning of the .bc path and therefore:

```
/usr/local/llvm14/bin/llvm-link: No such file or directory
```