### PR TITLE
[analyzer] Use pip to install package (#233).

### DIFF
--- a/analyzer/CMakeLists.txt
+++ b/analyzer/CMakeLists.txt
@@ -361,16 +361,16 @@ add_custom_target(ikos-python ALL
 )
 
 install(CODE "
-  set(PYTHON_SETUP_INSTALL
-    \"${PYTHON_EXECUTABLE}\"
-    \"setup.py\"
+  set(PIP_INSTALL
+    \"pip\"
     \"install\"
-    \"--prefix=${CMAKE_INSTALL_PREFIX}\"
   )
   if (DEFINED ENV{DESTDIR})
-    list(APPEND PYTHON_SETUP_INSTALL \"--root=\$ENV{DESTDIR}\")
+    list(APPEND PIP_INSTALL \"--target=\$ENV{DESTDIR}\")
   endif()
-  execute_process(COMMAND \${PYTHON_SETUP_INSTALL}
+  list(APPEND PIP_INSTALL \".\")
+
+  execute_process(COMMAND \${PIP_INSTALL}
                   WORKING_DIRECTORY \"${CMAKE_CURRENT_BINARY_DIR}/python\")
 ")
 


### PR DESCRIPTION
The current installation scripts for python programs don't place files exactly where/how expected, resulting in errors like:

```
$ ikos
error: could not find ikos python module
error: see TROUBLESHOOTING.md
```

even when PYTHONPATH is set correctly.

Instead of trying to fix the issue, it's worth it to switch to an alternative that is more up-to-date, where the problem does not happen.

The current installation scripts for python programs included in IKOS use easy_install, which has been deprecated
(https://setuptools.pypa.io/en/latest/history.html#v58-3-0).

This commit replaces calls to the setup.py script, with calls to pip, which is one of the recommended solutions for python package installation.