### PR TITLE
Adjust check of sqlite3 version on MacOS (#223).

### DIFF
--- a/analyzer/CMakeLists.txt
+++ b/analyzer/CMakeLists.txt
@@ -361,16 +361,16 @@ add_custom_target(ikos-python ALL
 )
 
 install(CODE "
-  set(PYTHON_SETUP_INSTALL
-    \"${PYTHON_EXECUTABLE}\"
-    \"setup.py\"
+  set(PIP_INSTALL
+    \"pip\"
     \"install\"
-    \"--prefix=${CMAKE_INSTALL_PREFIX}\"
   )
   if (DEFINED ENV{DESTDIR})
-    list(APPEND PYTHON_SETUP_INSTALL \"--root=\$ENV{DESTDIR}\")
+    list(APPEND PIP_INSTALL \"--target=\$ENV{DESTDIR}\")
   endif()
-  execute_process(COMMAND \${PYTHON_SETUP_INSTALL}
+  list(APPEND PIP_INSTALL \".\")
+
+  execute_process(COMMAND \${PIP_INSTALL}
                   WORKING_DIRECTORY \"${CMAKE_CURRENT_BINARY_DIR}/python\")
 ")
 

--- a/cmake/FindSQLite3.cmake
+++ b/cmake/FindSQLite3.cmake
@@ -63,7 +63,12 @@ if (NOT SQLITE3_FOUND)
       #include <sqlite3.h>
 
       int main() {
+      // The following assertion does not always hold on macs, due to a bug in
+      // the sqlite3 setup shipped on Mac. So, we only check if the OS is not
+      // Apple.
+      #ifndef __APPLE__
         assert(strcmp(SQLITE_VERSION, sqlite3_libversion()) == 0);
+      #endif
         printf(\"%s\", sqlite3_libversion());
         return 0;
       }


### PR DESCRIPTION
Installation on MacOS fails partly because a sqlite3-related assertion in one of the pre-installation checks does not hold on MacOS. More specifically, the assertion in question is whether the version numbers of sqlite3 in the string SQLITE_VERSION and the one returned by sqlite3_libversion are the same. This is a known issue with the sqlite3 library, and is external to IKOS.

This commit adds a condition around that assertion so that it is not checked on MacOS.