### PR TITLE
analyzer: Use `pip` module instead of tool to install IKOS (#242).

### DIFF
--- a/analyzer/CMakeLists.txt
+++ b/analyzer/CMakeLists.txt
@@ -362,6 +362,8 @@ add_custom_target(ikos-python ALL
 
 install(CODE "
   set(PIP_INSTALL
+    \"${PYTHON_EXECUTABLE}\"
+    \"-m\"
     \"pip\"
     \"install\"
   )


### PR DESCRIPTION
The installation script assumes that the tool pip is available, which may not be true.

This commit replaces calls to the `pip` tool with calls to `python` using `pip` as the module.

This change was actually contributed by Maxime Arthaud.