### PR TITLE
Bump copyright years in ikos CLI tool (c) notice (#249).

### DIFF
--- a/analyzer/python/ikos/args.py
+++ b/analyzer/python/ikos/args.py
@@ -126,7 +126,7 @@ def parse_argument(parser, name, choices, groups, default, value):
 class VersionAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         print('ikos %s' % settings.VERSION)
-        print('Copyright (c) 2011-2019 United States Government as represented'
+        print('Copyright (c) 2011-2023 United States Government as represented'
               ' by the')
         print('Administrator of the National Aeronautics and Space '
               'Administration.')


### PR DESCRIPTION
The copyright years reported by IKOS when executed with `--version` from the command line does not include the latest changes.

This commit bumps the upper bound of the Copyright years in the notice presented to users when run from the command-line, to include the current year.