### PR TITLE
Add some missing cstdint includes

### DIFF
--- a/core/include/ikos/core/domain/machine_int/operator.hpp
+++ b/core/include/ikos/core/domain/machine_int/operator.hpp
@@ -43,6 +43,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include <ikos/core/number/signedness.hpp>
 #include <ikos/core/support/assert.hpp>
 

--- a/core/include/ikos/core/semantic/indexable.hpp
+++ b/core/include/ikos/core/semantic/indexable.hpp
@@ -44,6 +44,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 
 #include <ikos/core/support/mpl.hpp>
 


### PR DESCRIPTION
Newer versions of GCC have become more strict about this, resulting in errors similar to the following:

````
In file included from /<<PKGBUILDDIR>>/core/include/ikos/core/domain/machine_int/abstract_domain.hpp:47,
                 from /<<PKGBUILDDIR>>/core/include/ikos/core/domain/machine_int/interval.hpp:46,
                 from /<<PKGBUILDDIR>>/analyzer/src/analysis/pointer/pointer.cpp:48:
/<<PKGBUILDDIR>>/core/include/ikos/core/domain/machine_int/operator.hpp:97:24: error: ‘uint64_t’ has not been declared
   97 |                        uint64_t result_bit_width,
      |                        ^~~~~~~~
```