### PR TITLE
Added translation for LLVM FNeg instruction.

### DIFF
--- a/frontend/llvm/src/import/function.cpp
+++ b/frontend/llvm/src/import/function.cpp
@@ -375,6 +375,16 @@ void FunctionImporter::translate_instruction(
   } else if (llvm::isa< llvm::SwitchInst >(inst)) {
     // The preprocessor should use the -lowerswitch pass
     throw ImportError("llvm switch instructions are not supported");
+  } else if (inst->getOpcode() == llvm::Instruction::FNeg) {
+    auto* binary_inst =
+        llvm::BinaryOperator::Create(llvm::BinaryOperator::FMul,
+                                     llvm::ConstantFP::get(inst->getOperand(0)
+                                                               ->getType(),
+                                                           -1.0),
+                                     inst->getOperand(0));
+    inst->replaceAllUsesWith(binary_inst);
+    binary_inst->setDebugLoc(inst->getDebugLoc());
+    this->translate_binary_operator(bb_translation, binary_inst);
   } else {
     std::ostringstream buf;
     buf << "unsupported llvm instruction: " << inst->getOpcodeName() << " [1]";
@@ -2022,6 +2032,10 @@ FunctionImporter::TypeHint FunctionImporter::infer_type_hint_use(
   } else if (llvm::isa< llvm::ShuffleVectorInst >(user)) {
     return {}; // no hint
   } else if (llvm::isa< llvm::ResumeInst >(user)) {
+    return {}; // no hint
+  } else if (llvm::isa< llvm::Instruction >(user) &&
+             llvm::cast< llvm::Instruction >(user)->getOpcode() ==
+                 llvm::Instruction::FNeg) {
     return {}; // no hint
   } else if (llvm::isa< llvm::SelectInst >(user)) {
     // The preprocessor should use the -lower-select pass

--- a/frontend/llvm/test/regression/import/fneg/test-1-float.c
+++ b/frontend/llvm/test/regression/import/fneg/test-1-float.c
@@ -1,0 +1,5 @@
+
+int main() {
+  float y = 10.0F;
+  return (int)(-y);
+}

--- a/frontend/llvm/test/regression/import/fneg/test-2-double.c
+++ b/frontend/llvm/test/regression/import/fneg/test-2-double.c
@@ -1,0 +1,5 @@
+
+int main() {
+  double y = 10.0F;
+  return (int)(-y);
+}


### PR DESCRIPTION
Added translation for LLVM FNeg instruction. No hint. 
Implementation is a modification of the [patch](https://github.com/NASA-SW-VnV/ikos/issues/197#issuecomment-1519336498) by @phoon0416. Using multiplcation by `-1.0` instead of subtracting from `-0.0`.
Added two tests, one for float and one for double that should successfully be analysed with ikos with the FNeg addition without throwing an unsupported LLVM instruction exception.

From the [LLVM Language reference manual](https://llvm.org/docs/LangRef.html#fneg-instruction)

>The value produced is a copy of the operand with its sign bit flipped. The value is otherwise completely identical; in particular, if the input is a NaN, then the quiet/signaling bit and payload are perfectly preserved.

Using [compiler explorer](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DIApACYAQuYukl9ZATwDKjdAGFUtAK4sGISQCspK4AMngMmAByPgBGmMQgZgDMpAAOqAqETgwe3r7%2BQemZjgJhEdEscQnJtpj2JQxCBEzEBLk%2BfoG19dlNLQRlUbHxiSkKza3t%2BV3j/YMVVaMAlLaoXsTI7BwmGgCCO/vJ4cjeWADUJkluyOPoWFSX2AfmScenmBdXtHgshAqPzyODBOXnOl2ut3CBABexeb1BH3BTnGxEwrBhh1ewPenzc/GILCY0KSTz2ULOhPCEDOS2eAHYrHszsyzmgGOMzug1jF6GcAI4MC4M24gEAMHzxPDIAD631%2BBH%2BVy5Xh5mEeor5XjwmAI0siTEiEFpdIAIpdGbsWayBByRSAtYIAGySaUEfkMaUxIUWABUqKh8VSqN1onG4LZtoI6FFDoIztdPseEHMjoFxrNSQtVojbuVqrODAAXiYGQBaDQAOg0JYzWZZObOdtj8bdRc93r9mADxCDOuloeJ1xtbqbUJbiZJybMjqL6fNzyZ9eHnO5vOLDMr1dN88XzIbo6dLrdhfbJd9/sEgeD/aYYau%2B6jMbHR4n2CnjsLc8zC/2u8bj5QNZB3BO18UJAgpzMABFSJdkiT4TW9GtSG9EBVBrCsTACNwGHMMwUIFAiPRiWlvz/O00C8YCrlAkhwMgyIAC0EKQ00ULPNCMKwnC8JQos%2BJPEid0tFkKKA8EQIAsCiUg5jLkQs9kNQ9DTUw7DcLMfCzkLFDBNIus92XPNeQYAVpQUFUzyLUsBRrYTs2XA84yPAszIsmJTwZTtu17ENb0HB9o3tZ8EyTFNTI9dyvwM/8gso6i3FogkZLwjRSxguCWMUtjlK49TeNcyKVT4tyVU9fSfwc9lc1XD4IvMlUuDPQsbNw7cyJEwzqtip9D1dQqGpiLhPPPLtLx7a8B3DRyAObF8wuner3K4aKDitMSqIkmipLolLNPLdLYPg%2BTWJNdiGU41TuI0rSlsakqiqG8rhLWpduuMuqzJYLxaDPUsuCrM4fXdOyOqqyMgrm/r6u%2B2hTySBSvIvAgrz7Kb7xmyGQoIV93xhn7VvIgD4q2xKduSiC8P%2BwHgYy46EdO86LEuk01J4zSHulWHOdh56OterqOQ%2BgaImAP7bPamLAt65zobM0X4cR0afMm/zpu6pzxwWmd5cwYBCc6nrAM2q5JKC6TKf2umsoZJSOJU1nroK%2BrRc5hWhP57c9g4FZaE4AJeD8DgtFIVBODcaxrEbNYNkRZIeFIAhNB9lYAGsQEdJIK0kAAOMw6SSJIzBzyQkkkABOOkAkdfROEkXgWAkDQNFIIOQ7DjheAUEAW6T4OfdIOBYCQTBVEwZAqJIchKBaYAFGUQw6iEBBUAAdyDhO0BYVI6CJbIF4iWhl7XtveC3nf6ASOfmFSBQV4IUhz7oeJ9TYTgz9Qbfn%2BIAB5Kjj/XsnYIY9kC7GIHPd%2BwDx5NHwEHXg/BBAiDEOwKQMhBCKBUOofupBdBcH0IYYwkdLD6DwDEbusBmBvyoCwB%2BAA3EYHBy5cC0EsFYqBUgNG7hwUstx5KmEsNYMwGgzilgAOpiFoCI0Ro8CDECYFI1ImB0CGEcMgXgqB6HEGIHgLA5CjSkGIF4QQPxMAABVUCeD0SsBQMdNh6EhAwA%2BS8V6AO4LwWRmAtgJ1XnI1InAeC%2B39oHIBHdsAgMnsQM4qgc6OlLM6M4wBkDIDOBAWRRjU5LBSRHARxCzi4EICQC48cljuOTqw0gCA0RYASPo9OSRHQVgCFwOk05HR0i4NXAIGhpy1w4PXVuITIHd17mUwJHAzDBOwR3Up/dymaMyM4SQQA%3D%3D) to test:
Using `(-0.0) - NaN` does not flip the bit. Same with `-1.0 * NaN`. `-NaN` does flip the bit.

The code in this PR does not quite adhere to the LLVM requirements of FNeg, but should cover most use cases.