### PR TITLE
`[frontend]` Replace calls to deprecated function `getAlignment` (#304).

### DIFF
--- a/frontend/llvm/src/import/function.cpp
+++ b/frontend/llvm/src/import/function.cpp
@@ -392,9 +392,10 @@ void FunctionImporter::translate_alloca(BasicBlockTranslation* bb_translation,
   ar::Type* allocated_type = var_type->pointee();
 
   // Translate local variable
-  ar::LocalVariable* var = ar::LocalVariable::create(this->_ar_fun,
-                                                     var_type,
-                                                     alloca->getAlignment());
+  ar::LocalVariable* var =
+      ar::LocalVariable::create(this->_ar_fun,
+                                var_type,
+                                alloca->getAlign().value());
   this->mark_variable_mapping(alloca, var);
 
   // Translate array size
@@ -423,7 +424,7 @@ void FunctionImporter::translate_store(BasicBlockTranslation* bb_translation,
 
   auto stmt = ar::Store::create(pointer,
                                 value,
-                                store->getAlignment(),
+                                store->getAlign().value(),
                                 store->isVolatile());
   stmt->set_frontend< llvm::Value >(store);
   bb_translation->add_statement(std::move(stmt));
@@ -443,7 +444,10 @@ void FunctionImporter::translate_load(BasicBlockTranslation* bb_translation,
                                              ptr_type);
 
   auto stmt =
-      ar::Load::create(var, pointer, load->getAlignment(), load->isVolatile());
+      ar::Load::create(var,
+                       pointer,
+                       load->getAlign().value(),
+                       load->isVolatile());
   stmt->set_frontend< llvm::Value >(load);
   bb_translation->add_statement(std::move(stmt));
 }


### PR DESCRIPTION
The function llvm::AllocaInst::getAlignment was deprecated in llvm-14 and removed in llvm-15. To facilitate IKOS working with newer versions of llvm, we should replace calls to getAlignment() with calls to getAlign().value().

This commit replaces several occurrences of getAlignment with calls to getAlign. The replacement only occurs in cases where it is clear that the expansion is possible (there is an alignment). Other calls (e.g., when the call returns an optional value) are not replaced, since there is a disagreement between the current implementation of `getAlignment` for those classes in terms of the new `getAlign` and the current interface of `MaybeAlign`.