### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@
 #
 #*****************************************************************************/
 
-cmake_minimum_required(VERSION 3.4.3 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.4.3...4.0 FATAL_ERROR)
 
 project(ikos)
 set(PACKAGE_VERSION "3.5")


### PR DESCRIPTION
Add additional cmake_minimum_required argument to allow cmake versions >4 to build when downloading from homebrew.