### PR TITLE
Fix GaugeBound::operator=(Number) to assign to _cst (closes #331)

### DIFF
--- a/core/include/ikos/core/value/numeric/gauge.hpp
+++ b/core/include/ikos/core/value/numeric/gauge.hpp
@@ -167,7 +167,7 @@ public:
   /// \brief Assign a number
   GaugeBound& operator=(Number n) {
     this->_is_infinite = false;
-    this->_n = std::move(n);
+    this->_cst = std::move(n);
     this->_coeffs.clear();
     return *this;
   }


### PR DESCRIPTION
The Number-overload of the assignment operator was writing to a non-existent _n member instead of the _cst constant member, matching the int overload above it.